### PR TITLE
415: Fix Save button issues

### DIFF
--- a/src/app/find-properties/[[...opa_id]]/page.tsx
+++ b/src/app/find-properties/[[...opa_id]]/page.tsx
@@ -298,6 +298,9 @@ const MapPage = ({ params }: MapPageProps) => {
                   setSelectedProperty={setSelectedProperty}
                   setIsStreetViewModalOpen={setIsStreetViewModalOpen}
                   shouldFilterSavedProperties={shouldFilterSavedProperties}
+                  setShouldFilterSavedProperties={
+                    setShouldFilterSavedProperties
+                  }
                   smallScreenMode={smallScreenMode}
                   updateCurrentView={updateCurrentView}
                 />

--- a/src/components/PropertyDetailSection.tsx
+++ b/src/components/PropertyDetailSection.tsx
@@ -52,6 +52,7 @@ interface PropertyDetailSectionProps {
   setSelectedProperty: (property: MapGeoJSONFeature | null) => void;
   setIsStreetViewModalOpen: Dispatch<SetStateAction<boolean>>;
   shouldFilterSavedProperties: boolean;
+  setShouldFilterSavedProperties: (shouldFilter: boolean) => void;
   smallScreenMode: string;
   updateCurrentView: (view: BarClickOptions) => void;
 }
@@ -64,6 +65,7 @@ const PropertyDetailSection: FC<PropertyDetailSectionProps> = ({
   setSelectedProperty,
   setIsStreetViewModalOpen,
   shouldFilterSavedProperties,
+  setShouldFilterSavedProperties,
   updateCurrentView,
   smallScreenMode,
 }) => {
@@ -184,6 +186,7 @@ const PropertyDetailSection: FC<PropertyDetailSectionProps> = ({
       setSelectedProperty={setSelectedProperty}
       setIsStreetViewModalOpen={setIsStreetViewModalOpen}
       shouldFilterSavedProperties={shouldFilterSavedProperties}
+      setShouldFilterSavedProperties={setShouldFilterSavedProperties}
       updateCurrentView={updateCurrentView}
     />
   ) : (

--- a/src/components/SidePanelControlBar.tsx
+++ b/src/components/SidePanelControlBar.tsx
@@ -83,11 +83,14 @@ const SearchBarComponent: FC<SidePanelControlBarProps> = ({
         />
         <div className="sm:px-4 py-2">
           <h1 className="body-md">
-            <span className="font-bold">{featureCount.toLocaleString()} </span>
+            <span className="font-bold">
+              {shouldFilterSavedProperties
+                ? savedPropertyCount
+                : featureCount.toLocaleString()}{" "}
+            </span>
             Properties <span className="max-xl:hidden"> in View </span>
           </h1>
         </div>
-
         {/* Right-aligned content: Buttons */}
         <div
           className="flex items-center space-x-2"

--- a/src/components/SidePanelControlBar.tsx
+++ b/src/components/SidePanelControlBar.tsx
@@ -40,7 +40,12 @@ const SearchBarComponent: FC<SidePanelControlBarProps> = ({
   const savedRef = useRef<HTMLButtonElement | null>(null);
   const { dispatch, appFilter } = useFilter();
 
-  const filterCount = Object.keys(appFilter).length;
+  let filterCount = Object.keys(appFilter).length;
+
+  if (shouldFilterSavedProperties) {
+    // Exclude OPA_ID from filterCount, which counts OPA_ID as a filter by default
+    filterCount--;
+  }
 
   const onClickSavedButton = () => {
     let propertyIds = getPropertyIdsFromLocalStorage();

--- a/src/components/SinglePropertyDetail.tsx
+++ b/src/components/SinglePropertyDetail.tsx
@@ -187,6 +187,16 @@ const SinglePropertyDetail = ({
 
         {/* Right-aligned content: Buttons */}
         <div className="flex items-center">
+          <ThemeButton
+            color="tertiary"
+            label={isPropertySavedToLocalStorage ? "Saved" : "Save"}
+            startContent={<BookmarkSimple />}
+            onPress={() => {
+              onClickSaveButton();
+            }}
+            isSelected={isPropertySavedToLocalStorage}
+          />
+
           <Tooltip
             disableAnimation
             closeDelay={100}
@@ -209,16 +219,6 @@ const SinglePropertyDetail = ({
               onMouseLeave={() => setHover(false)}
             />
           </Tooltip>
-
-          <ThemeButton
-            color="tertiary"
-            label={isPropertySavedToLocalStorage ? "Saved" : "Save"}
-            startContent={<BookmarkSimple />}
-            onPress={() => {
-              onClickSaveButton();
-            }}
-            isSelected={isPropertySavedToLocalStorage}
-          />
         </div>
       </div>
       <div className="bg-white rounded-lg overflow-hidden">

--- a/src/components/SinglePropertyDetail.tsx
+++ b/src/components/SinglePropertyDetail.tsx
@@ -23,6 +23,7 @@ interface PropertyDetailProps {
   setSelectedProperty: (property: MapGeoJSONFeature | null) => void;
   setIsStreetViewModalOpen: Dispatch<SetStateAction<boolean>>;
   shouldFilterSavedProperties: boolean;
+  setShouldFilterSavedProperties: (shouldFilter: boolean) => void;
   updateCurrentView: (view: BarClickOptions) => void;
 }
 
@@ -51,6 +52,7 @@ const SinglePropertyDetail = ({
   setSelectedProperty,
   setIsStreetViewModalOpen,
   shouldFilterSavedProperties,
+  setShouldFilterSavedProperties,
   updateCurrentView,
 }: PropertyDetailProps) => {
   const { dispatch } = useFilter();
@@ -152,6 +154,7 @@ const SinglePropertyDetail = ({
           property: "OPA_ID",
           dimensions: [],
         });
+        setShouldFilterSavedProperties(false);
       } else {
         if (shouldFilterSavedProperties) {
           let propertyIds = getPropertyIdsFromLocalStorage();


### PR DESCRIPTION
## Description

This PR fixes the following issues from PR #587 with the feature, "Save properties to local storage":

- UI displays wrong count for "# Properties in View." This PR fixes the issue by showing `savedPropertyCount` instead of  `featureCount` if a user is viewing a list of saved properties.
- Filter button is changing to a selected state and showing a filterCount of "(1)" if a user is filtering by saved properties. This PR fixes the issue by overriding this default behavior and excluding OPA_ID from `filterCount`. Filter button now remains unchanged if user views a list of saved properties. 

## Screen recording

https://github.com/CodeForPhilly/clean-and-green-philly/assets/7751862/9e105ee9-6266-4ef3-8640-71d17b0752a1


Closes #415 