### PR TITLE
Bug Fix: Correct flashing of filter button color on select & hover

### DIFF
--- a/src/components/Filters/DimensionFilter.tsx
+++ b/src/components/Filters/DimensionFilter.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, FC } from "react";
+import React, { useMemo, useState, FC } from "react";
 import { useFilter } from "@/context/FilterContext";
 import ButtonGroup from "./ButtonGroup";
 import MultiSelect from "./MultiSelect";
@@ -67,35 +67,35 @@ const DimensionFilter: FC<DimensionFilterProps> = ({
     });
   };
 
-  const Filter = () => {
-    if (type === "buttonGroup") {
-      return (
-        <ButtonGroup
-          options={options}
-          selectedKeys={selectedKeys}
-          toggleDimension={toggleDimension}
-        />
-      );
-    } else if (type === "panels") {
-      return (
-        <Panels 
-          options={options}
-          selectedPanelKeys={selectedPanelKeys}
-          toggleDimensionForPanel={toggleDimensionForPanel}
-        />
-      )
-    } else {
-      return (
-        <MultiSelect
-          display={display}
-          options={options}
-          selectedKeys={selectedKeys}
-          toggleDimension={toggleDimension}
-          handleSelectionChange={handleSelectionChange}
-        />
-      );
-    }
-  };
+  const filter = useMemo(() => {
+      if (type === "buttonGroup") {
+        return (
+          <ButtonGroup
+            options={options}
+            selectedKeys={selectedKeys}
+            toggleDimension={toggleDimension}
+          />
+        );
+      } else if (type === "panels") {
+        return (
+          <Panels 
+            options={options}
+            selectedPanelKeys={selectedPanelKeys}
+            toggleDimensionForPanel={toggleDimensionForPanel}
+          />
+        )
+      } else {
+        return (
+          <MultiSelect
+            display={display}
+            options={options}
+            selectedKeys={selectedKeys}
+            toggleDimension={toggleDimension}
+            handleSelectionChange={handleSelectionChange}
+          />
+        );
+      }
+    }, [selectedKeys, selectedPanelKeys])
 
   const filterDescription =
     property === "priority_level"
@@ -125,7 +125,7 @@ const DimensionFilter: FC<DimensionFilterProps> = ({
           </p>
         )}
       </div>
-      <Filter />
+      {filter}
     </div>
   );
 };

--- a/src/components/Filters/Panels.tsx
+++ b/src/components/Filters/Panels.tsx
@@ -86,7 +86,6 @@ const Panels: FC<PanelsProps> = ({
         key={index}
         className={isSelected ? "panelSelected " : "panelDefault"}
         isPressable
-        isHoverable={false}
         onPress={() => toggleDimensionForPanel(panel.dimension, panel.property)}
         shadow="none"
       >


### PR DESCRIPTION
This addresses the strobing color issue in #601 

The issue was caused by the filters being re-rendered twice whenever they were selected or deselected.  This PR resolves the issue by putting the `filter` array inside a useMemo that only updates when the `selectedKeys` or `selectedPanelKeys` states change.

https://github.com/CodeForPhilly/clean-and-green-philly/assets/140654473/c583d2c7-1efb-408f-b2d1-dcaf995b69b0