### PR TITLE
build: first draft of CI pipeline

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -1,0 +1,27 @@
+name: Frontend PR Checks
+on: # see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "src/**/*"
+      - "package.json"
+      - "package-lock.json"
+      - "*.js"
+jobs:
+  lint_and_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: "package-lock.json"
+      - name: Install dependencies
+        run: npm ci
+      - name: Run lints
+        run: npm run lint
+      - name: Check the build
+        run: npm run build


### PR DESCRIPTION
A quick-and-dirty pipeline to ensure incoming PRs don't introduce any new linting errors and don't break the build. Once merged, the pipeline should fire on every PR that affects the frontend since [GH Actions are enabled by default](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#about-github-actions-permissions-for-your-repository).