### PR TITLE
618: Change card titles to H3 tags on Transform Property page

### DIFF
--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -62,7 +62,7 @@ const ContentCard: FC<ContentCardProps> = ({
       </div>
       <div className="flex items-center p-6">
         <div>
-          <h4 className="font-bold mb-2 heading-lg">{title}</h4>
+          <h3 className="font-bold mb-2 heading-lg">{title}</h3>
           <p>{body}</p>
 
           {details && details.length > 0 && (


### PR DESCRIPTION
## Description

This PR changes `<h4>` tags to `<h3>` on the Transform Property page, so the page no longer skips heading levels. This improves user accessibility.

This PR changes the tags for both Basic Intervention and Advanced Intervention card titles.

## Screenshots

Before PR:

<img width="1272" alt="Screen Shot 2024-05-02 at 7 58 59 PM" src="https://github.com/CodeForPhilly/clean-and-green-philly/assets/7751862/3daaaa6e-85a5-4a75-9e93-4d09d9b1d373">


After PR:

<img width="1098" alt="Screen Shot 2024-05-03 at 2 16 41 AM" src="https://github.com/CodeForPhilly/clean-and-green-philly/assets/7751862/f25fcb1e-2d24-4294-afbb-1f63b5710416">


Closes #618 