### PR TITLE
597: Accept or Decline Cookies

### DIFF
--- a/src/app/(content-pages)/layout.tsx
+++ b/src/app/(content-pages)/layout.tsx
@@ -1,21 +1,16 @@
-"use client";
-
 import { Footer, Header, Hotjar } from "@/components";
-import { CookieProvider } from "@/context/CookieContext";
 
 const ContentPagesLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
-      <CookieProvider>
-        <Header />
-        <main id="main">
-          <div className="max-w-[68.75rem] mx-auto pb-[30px] pt-[60px] w-[90%]">
-            {children}
-          </div>
-        </main>
-        <Footer />
-        <Hotjar />
-      </CookieProvider>
+      <Header />
+      <main id="main">
+        <div className="max-w-[68.75rem] mx-auto pb-[30px] pt-[60px] w-[90%]">
+          {children}
+        </div>
+      </main>
+      <Footer />
+      <Hotjar />
     </>
   );
 };

--- a/src/app/(content-pages)/layout.tsx
+++ b/src/app/(content-pages)/layout.tsx
@@ -1,16 +1,21 @@
+"use client";
+
 import { Footer, Header, Hotjar } from "@/components";
+import { CookieProvider } from "@/context/CookieContext";
 
 const ContentPagesLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
-      <Header />
-      <main id="main">
-        <div className="max-w-[68.75rem] mx-auto pb-[30px] pt-[60px] w-[90%]">
+      <CookieProvider>
+        <Header />
+        <main id="main">
+          <div className="max-w-[68.75rem] mx-auto pb-[30px] pt-[60px] w-[90%]">
             {children}
-        </div>
-      </main>
-      <Footer />
-      <Hotjar />
+          </div>
+        </main>
+        <Footer />
+        <Hotjar />
+      </CookieProvider>
     </>
   );
 };

--- a/src/app/CookieProviderWrapper.tsx
+++ b/src/app/CookieProviderWrapper.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { CookieProvider } from "@/context/CookieContext";
+
+export const CookieProviderWrapper = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  return <CookieProvider>{children}</CookieProvider>;
+};

--- a/src/app/find-properties/[[...opa_id]]/layout.tsx
+++ b/src/app/find-properties/[[...opa_id]]/layout.tsx
@@ -1,4 +1,5 @@
 import { Header, Hotjar } from "@/components";
+import CookieConsentBanner from "@/components/CookieConsentBanner";
 
 export const metadata = {
   title: "Find Properties",
@@ -10,6 +11,7 @@ const MapLayout = ({ children }: { children: React.ReactNode }) => {
       <Header />
       <main id="main">{children}</main>
       <Hotjar />
+      <CookieConsentBanner />
     </div>
   );
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { CookieProviderWrapper } from "./CookieProviderWrapper";
 
 export const metadata: Metadata = {
   title: {
@@ -28,7 +29,7 @@ export default function RootLayout({
         >
           Skip to main content
         </a>
-        {children}
+        <CookieProviderWrapper>{children}</CookieProviderWrapper>
       </body>
     </html>
   );

--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -1,19 +1,16 @@
 "use client";
 
-import { useState } from "react";
 import { ThemeButton } from "./ThemeButton";
 import { Check, X } from "@phosphor-icons/react";
 import { useCookieContext } from "@/context/CookieContext";
 
 const CookieConsentBanner = () => {
-  const [shouldStoreCookies, setShouldStoreCookies] = useState(false);
-  const { shouldShowBanner, setShouldShowBanner } = useCookieContext();
+  const { shouldShowBanner, setShouldAllowCookies, setShouldShowBanner } =
+    useCookieContext();
 
   const onClickButton = (shouldSaveCookies: boolean) => {
-    setShouldStoreCookies(shouldSaveCookies);
+    setShouldAllowCookies(shouldSaveCookies);
     setShouldShowBanner(false);
-
-    // TODO: Add logic for accepting or declining cookies. See issue 597.
   };
 
   return (

--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -3,23 +3,25 @@
 import { useState } from "react";
 import { ThemeButton } from "./ThemeButton";
 import { Check, X } from "@phosphor-icons/react";
+import { useCookieContext } from "@/context/CookieContext";
 
 const CookieConsentBanner = () => {
-  const [cookieConsent, setCookieConsent] = useState(false);
+  const [shouldStoreCookies, setShouldStoreCookies] = useState(false);
+  const { shouldShowBanner, setShouldShowBanner } = useCookieContext();
 
-  const onClickButton = (shouldAllowCookies: boolean) => {
-    setCookieConsent(true);
+  const onClickButton = (shouldSaveCookies: boolean) => {
+    setShouldStoreCookies(shouldSaveCookies);
+    setShouldShowBanner(false);
 
     // TODO: Add logic for accepting or declining cookies. See issue 597.
-    console.log("shouldAllowCookies", shouldAllowCookies);
   };
 
   return (
     <div
       className={`${
-        cookieConsent
-          ? "hidden"
-          : "md:flex fixed inset-x-0 bottom-0 z-20 justify-between bg-blue-200 p-4 sm:p-6"
+        shouldShowBanner
+          ? "md:flex fixed inset-x-0 bottom-0 z-20 justify-between bg-blue-200 p-4 sm:p-6"
+          : "hidden"
       }`}
     >
       <div>

--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -30,7 +30,7 @@ const CookieConsentBanner = () => {
         </div>
       </div>
 
-      <div className="flex justify-end gap-2">
+      <div className="flex justify-end gap-2 pt-4 sm:pt-0">
         <div className="flex flex-none items-center gap-x-2">
           <ThemeButton
             color="tertiary"

--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+import { ThemeButton } from "./ThemeButton";
+import { Check, X } from "@phosphor-icons/react";
+
+const CookieConsentBanner = () => {
+  const [cookieConsent, setCookieConsent] = useState(false);
+
+  const onClickButton = (shouldAllowCookies: boolean) => {
+    setCookieConsent(true);
+
+    // TODO: Add logic for accepting or declining cookies. See issue 597.
+    console.log("shouldAllowCookies", shouldAllowCookies);
+  };
+
+  return (
+    <div
+      className={`${
+        cookieConsent === true
+          ? "hidden"
+          : "flex fixed inset-x-0 bottom-0 z-20 justify-between bg-blue-200 p-6"
+      }`}
+    >
+      <div>
+        <div className="heading-md">Can we store cookies to your browser?</div>
+        <div className="body-sm">
+          This provides you a nice experience preserving your filtering, your
+          position on the map and your property saved list.
+        </div>
+      </div>
+
+      <div className="flex gap-2">
+        <div className="flex flex-none items-center gap-x-5">
+          <ThemeButton
+            color="tertiary"
+            label="Decline"
+            startContent={<X />}
+            onPress={() => onClickButton(false)}
+          />
+
+          <ThemeButton
+            color="primary"
+            label="Accept"
+            startContent={<Check />}
+            onPress={() => onClickButton(true)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CookieConsentBanner;

--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -17,9 +17,9 @@ const CookieConsentBanner = () => {
   return (
     <div
       className={`${
-        cookieConsent === true
+        cookieConsent
           ? "hidden"
-          : "flex fixed inset-x-0 bottom-0 z-20 justify-between bg-blue-200 p-6"
+          : "md:flex fixed inset-x-0 bottom-0 z-20 justify-between bg-blue-200 p-4 sm:p-6"
       }`}
     >
       <div>
@@ -30,8 +30,8 @@ const CookieConsentBanner = () => {
         </div>
       </div>
 
-      <div className="flex gap-2">
-        <div className="flex flex-none items-center gap-x-5">
+      <div className="flex justify-end gap-2">
+        <div className="flex flex-none items-center gap-x-2">
           <ThemeButton
             color="tertiary"
             label="Decline"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,19 +1,42 @@
+"use client";
+
+import CookieConsentBanner from "./CookieConsentBanner";
+
+const onClickCookieSettings = () => {
+  // TODO: Add logic for showing cookie consent banner. See issue 597.
+};
+
 const Footer = () => (
   <div className="flex flex-col">
-    <footer className="px-6 h-16 flex flex-grow w-full items-center">
-      <nav className="w-full" aria-label="content info">
-        <ul className="flex flex-wrap gap-x-4 justify-between items-center w-full backdrop-saturate-150 bg-background/70">
+    <footer className="px-6 h-16 flex flex-grow justify-center items-center">
+      <nav aria-label="content info">
+        <ul className="flex flex-wrap gap-x-2 justify-between items-center w-full backdrop-saturate-150 bg-background/70">
           <li>
             <span className="base-sm text-gray-600">
               © 2024 Clean & Green Philly
             </span>
           </li>
 
+          <span className="max-sm:hidden">—</span>
+
+          <li className="base-sm underline text-gray-600 mx-auto">
+            <a
+              className="hover:text-gray-800 cursor-pointer"
+              onClick={onClickCookieSettings}
+            >
+              Cookie Settings
+            </a>
+          </li>
+
+          <span className="max-sm:hidden">—</span>
+
           <li className="base-sm underline text-gray-600 mx-auto">
             <a href="/legal-disclaimer" className="hover:text-gray-800">
               Legal Disclaimer
             </a>
           </li>
+
+          <span className="max-sm:hidden">—</span>
 
           <li>
             <a

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,6 +2,7 @@
 
 import { useCookieContext } from "@/context/CookieContext";
 import CookieConsentBanner from "./CookieConsentBanner";
+import Link from "next/link";
 
 const Footer = () => {
   let { setShouldShowBanner } = useCookieContext();
@@ -36,9 +37,9 @@ const Footer = () => {
             <span className="max-sm:hidden">—</span>
 
             <li className="base-sm underline text-gray-600 mx-auto">
-              <a href="/legal-disclaimer" className="hover:text-gray-800">
+              <Link href="/legal-disclaimer" className="hover:text-gray-800">
                 Legal Disclaimer
-              </a>
+              </Link>
             </li>
 
             <span className="max-sm:hidden">—</span>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,57 +1,63 @@
 "use client";
 
+import { useCookieContext } from "@/context/CookieContext";
 import CookieConsentBanner from "./CookieConsentBanner";
 
-const onClickCookieSettings = () => {
-  // TODO: Add logic for showing cookie consent banner. See issue 597.
+const Footer = () => {
+  let { setShouldShowBanner } = useCookieContext();
+
+  const onClickCookieSettings = () => {
+    // TODO: Add logic for showing cookie consent banner. See issue 597.
+    setShouldShowBanner(true);
+  };
+
+  return (
+    <div className="flex flex-col">
+      <footer className="px-6 h-16 flex flex-grow justify-center items-center">
+        <nav aria-label="content info">
+          <ul className="flex flex-wrap gap-x-2 justify-between items-center w-full backdrop-saturate-150 bg-background/70">
+            <li>
+              <span className="base-sm text-gray-600">
+                © 2024 Clean & Green Philly
+              </span>
+            </li>
+
+            <span className="max-sm:hidden">—</span>
+
+            <li className="base-sm underline text-gray-600 mx-auto">
+              <a
+                className="hover:text-gray-800 cursor-pointer"
+                onClick={onClickCookieSettings}
+              >
+                Cookie Settings
+              </a>
+            </li>
+
+            <span className="max-sm:hidden">—</span>
+
+            <li className="base-sm underline text-gray-600 mx-auto">
+              <a href="/legal-disclaimer" className="hover:text-gray-800">
+                Legal Disclaimer
+              </a>
+            </li>
+
+            <span className="max-sm:hidden">—</span>
+
+            <li>
+              <a
+                href="mailto:cleanandgreenphl@gmail.com"
+                className="base-sm underline text-gray-600 hover:text-gray-800"
+              >
+                Contact Us
+              </a>
+            </li>
+          </ul>
+        </nav>
+
+        <CookieConsentBanner />
+      </footer>
+    </div>
+  );
 };
-
-const Footer = () => (
-  <div className="flex flex-col">
-    <footer className="px-6 h-16 flex flex-grow justify-center items-center">
-      <nav aria-label="content info">
-        <ul className="flex flex-wrap gap-x-2 justify-between items-center w-full backdrop-saturate-150 bg-background/70">
-          <li>
-            <span className="base-sm text-gray-600">
-              © 2024 Clean & Green Philly
-            </span>
-          </li>
-
-          <span className="max-sm:hidden">—</span>
-
-          <li className="base-sm underline text-gray-600 mx-auto">
-            <a
-              className="hover:text-gray-800 cursor-pointer"
-              onClick={onClickCookieSettings}
-            >
-              Cookie Settings
-            </a>
-          </li>
-
-          <span className="max-sm:hidden">—</span>
-
-          <li className="base-sm underline text-gray-600 mx-auto">
-            <a href="/legal-disclaimer" className="hover:text-gray-800">
-              Legal Disclaimer
-            </a>
-          </li>
-
-          <span className="max-sm:hidden">—</span>
-
-          <li>
-            <a
-              href="mailto:cleanandgreenphl@gmail.com"
-              className="base-sm underline text-gray-600 hover:text-gray-800"
-            >
-              Contact Us
-            </a>
-          </li>
-        </ul>
-      </nav>
-
-      <CookieConsentBanner />
-    </footer>
-  </div>
-);
 
 export default Footer;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,7 +8,6 @@ const Footer = () => {
   let { setShouldShowBanner } = useCookieContext();
 
   const onClickCookieSettings = () => {
-    // TODO: Add logic for showing cookie consent banner. See issue 597.
     setShouldShowBanner(true);
   };
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -48,6 +48,8 @@ const Footer = () => (
           </li>
         </ul>
       </nav>
+
+      <CookieConsentBanner />
     </footer>
   </div>
 );

--- a/src/components/IconLink.tsx
+++ b/src/components/IconLink.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Button, Link, NavbarItem } from "@nextui-org/react";
+import { Button, NavbarItem } from "@nextui-org/react";
 import { usePathname } from "next/navigation";
+import Link from "next/link";
 
 interface IconLinkProps {
   icon: React.ReactElement;

--- a/src/components/SinglePropertyDetail.tsx
+++ b/src/components/SinglePropertyDetail.tsx
@@ -142,38 +142,45 @@ const SinglePropertyDetail = ({
 
   const onClickSaveButton = () => {
     if (shouldAllowCookies) {
-      const localStorageData = localStorage.getItem("opa_ids");
-      const parsedLocalStorageData = localStorageData
-        ? JSON.parse(localStorageData)
-        : {};
-
-      if (parsedLocalStorageData.opa_ids[OPA_ID]) {
-        removePropertyIdFromLocalStorage(parsedLocalStorageData);
-        setIsPropertySavedToLocalStorage(false);
-
-        if (parsedLocalStorageData.count === 0) {
-          dispatch({
-            type: "SET_DIMENSIONS",
-            property: "OPA_ID",
-            dimensions: [],
-          });
-          setShouldFilterSavedProperties(false);
-        } else {
-          if (shouldFilterSavedProperties) {
-            let propertyIds = getPropertyIdsFromLocalStorage();
-            dispatch({
-              type: "SET_DIMENSIONS",
-              property: "OPA_ID",
-              dimensions: [...propertyIds],
-            });
-          }
-        }
-      } else {
-        savePropertyIdToLocalStorage(parsedLocalStorageData);
-        setIsPropertySavedToLocalStorage(true);
-      }
+      findPropertyIdInLocalStorage();
     } else {
       setShouldShowBanner(true);
+    }
+  };
+
+  const findPropertyIdInLocalStorage = () => {
+    const localStorageData = localStorage.getItem("opa_ids");
+    const parsedLocalStorageData = localStorageData
+      ? JSON.parse(localStorageData)
+      : {};
+
+    if (parsedLocalStorageData.opa_ids[OPA_ID]) {
+      removePropertyIdFromLocalStorage(parsedLocalStorageData);
+      setIsPropertySavedToLocalStorage(false);
+      dispatchFilterAction(parsedLocalStorageData);
+    } else {
+      savePropertyIdToLocalStorage(parsedLocalStorageData);
+      setIsPropertySavedToLocalStorage(true);
+    }
+  };
+
+  const dispatchFilterAction = (data: any) => {
+    if (data.count === 0) {
+      dispatch({
+        type: "SET_DIMENSIONS",
+        property: "OPA_ID",
+        dimensions: [],
+      });
+      setShouldFilterSavedProperties(false);
+    } else {
+      if (shouldFilterSavedProperties) {
+        let propertyIds = getPropertyIdsFromLocalStorage();
+        dispatch({
+          type: "SET_DIMENSIONS",
+          property: "OPA_ID",
+          dimensions: [...propertyIds],
+        });
+      }
     }
   };
 

--- a/src/components/SinglePropertyDetail.tsx
+++ b/src/components/SinglePropertyDetail.tsx
@@ -16,6 +16,7 @@ import ContentCard from "./ContentCard";
 import cleanup from "@/images/transform-a-property.png";
 import { PiEyeSlash } from "react-icons/pi";
 import { useFilter } from "@/context/FilterContext";
+import { useCookieContext } from "@/context/CookieContext";
 import { getPropertyIdsFromLocalStorage } from "@/utilities/localStorage";
 
 interface PropertyDetailProps {
@@ -61,6 +62,7 @@ const SinglePropertyDetail = ({
   const [hover, setHover] = useState<boolean>(false);
   const [isPropertySavedToLocalStorage, setIsPropertySavedToLocalStorage] =
     useState(false);
+  let { shouldAllowCookies, setShouldShowBanner } = useCookieContext();
 
   useEffect(() => {
     if (!localStorage.getItem("opa_ids")) {
@@ -139,35 +141,39 @@ const SinglePropertyDetail = ({
   };
 
   const onClickSaveButton = () => {
-    const localStorageData = localStorage.getItem("opa_ids");
-    const parsedLocalStorageData = localStorageData
-      ? JSON.parse(localStorageData)
-      : {};
+    if (shouldAllowCookies) {
+      const localStorageData = localStorage.getItem("opa_ids");
+      const parsedLocalStorageData = localStorageData
+        ? JSON.parse(localStorageData)
+        : {};
 
-    if (parsedLocalStorageData.opa_ids[OPA_ID]) {
-      removePropertyIdFromLocalStorage(parsedLocalStorageData);
-      setIsPropertySavedToLocalStorage(false);
+      if (parsedLocalStorageData.opa_ids[OPA_ID]) {
+        removePropertyIdFromLocalStorage(parsedLocalStorageData);
+        setIsPropertySavedToLocalStorage(false);
 
-      if (parsedLocalStorageData.count === 0) {
-        dispatch({
-          type: "SET_DIMENSIONS",
-          property: "OPA_ID",
-          dimensions: [],
-        });
-        setShouldFilterSavedProperties(false);
-      } else {
-        if (shouldFilterSavedProperties) {
-          let propertyIds = getPropertyIdsFromLocalStorage();
+        if (parsedLocalStorageData.count === 0) {
           dispatch({
             type: "SET_DIMENSIONS",
             property: "OPA_ID",
-            dimensions: [...propertyIds],
+            dimensions: [],
           });
+          setShouldFilterSavedProperties(false);
+        } else {
+          if (shouldFilterSavedProperties) {
+            let propertyIds = getPropertyIdsFromLocalStorage();
+            dispatch({
+              type: "SET_DIMENSIONS",
+              property: "OPA_ID",
+              dimensions: [...propertyIds],
+            });
+          }
         }
+      } else {
+        savePropertyIdToLocalStorage(parsedLocalStorageData);
+        setIsPropertySavedToLocalStorage(true);
       }
     } else {
-      savePropertyIdToLocalStorage(parsedLocalStorageData);
-      setIsPropertySavedToLocalStorage(true);
+      setShouldShowBanner(true);
     }
   };
 

--- a/src/context/CookieContext.tsx
+++ b/src/context/CookieContext.tsx
@@ -7,7 +7,9 @@ import React, {
 } from "react";
 
 interface CookieContextProps {
+  shouldAllowCookies: boolean;
   shouldShowBanner: boolean;
+  setShouldAllowCookies: React.Dispatch<React.SetStateAction<boolean>>;
   setShouldShowBanner: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
@@ -28,10 +30,18 @@ export const useCookieContext = () => {
 };
 
 export const CookieProvider: FC<CookieProviderProps> = ({ children }) => {
+  const [shouldAllowCookies, setShouldAllowCookies] = useState(false);
   const [shouldShowBanner, setShouldShowBanner] = useState(true);
 
   return (
-    <CookieContext.Provider value={{ shouldShowBanner, setShouldShowBanner }}>
+    <CookieContext.Provider
+      value={{
+        shouldAllowCookies,
+        shouldShowBanner,
+        setShouldAllowCookies,
+        setShouldShowBanner,
+      }}
+    >
       {children}
     </CookieContext.Provider>
   );

--- a/src/context/CookieContext.tsx
+++ b/src/context/CookieContext.tsx
@@ -1,0 +1,38 @@
+import React, {
+  FC,
+  createContext,
+  useContext,
+  useState,
+  ReactNode,
+} from "react";
+
+interface CookieContextProps {
+  shouldShowBanner: boolean;
+  setShouldShowBanner: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+interface CookieProviderProps {
+  children: ReactNode;
+}
+
+export const CookieContext = createContext<CookieContextProps | undefined>(
+  undefined
+);
+
+export const useCookieContext = () => {
+  const context = useContext(CookieContext);
+  if (!context) {
+    throw new Error("useCookieContext must be used within a CookieProvider");
+  }
+  return context;
+};
+
+export const CookieProvider: FC<CookieProviderProps> = ({ children }) => {
+  const [shouldShowBanner, setShouldShowBanner] = useState(true);
+
+  return (
+    <CookieContext.Provider value={{ shouldShowBanner, setShouldShowBanner }}>
+      {children}
+    </CookieContext.Provider>
+  );
+};


### PR DESCRIPTION
## Description

This PR creates a cookie consent banner for users to accept or decline cookies in their Web browser.

When user declines cookies and then clicks the "Save Property" button, the property won't be saved. Instead, the cookie-consent banner will appear again and ask for their permission to save cookies in their browser.

Closes #597 


## Screenshots

### Desktop view
![Screen Shot 2024-05-28 at 11 46 42 PM](https://github.com/CodeForPhilly/clean-and-green-philly/assets/7751862/741d6019-e64e-4389-a173-e4fab7e8a61a)

### Mobile view
![Screen Shot 2024-05-28 at 11 45 44 PM](https://github.com/CodeForPhilly/clean-and-green-philly/assets/7751862/6ecd7267-128e-4500-b7d7-2ed0d4087ec5)


## Screen recordings

These videos show 3 of the scenarios where the cookie-consent banner will appear:

### 1) User visits homepage for the first time
### 2) User clicks "Cookie Settings" in footer

https://github.com/CodeForPhilly/clean-and-green-philly/assets/7751862/fd3beb44-841e-4161-8b33-ca67efc229bc


### 3) User clicks "Save Property" button after declining cookies

https://github.com/CodeForPhilly/clean-and-green-philly/assets/7751862/0cafa75e-958b-4ce5-808e-fb1209d2fbaf