### PR TITLE
Fix the issue of map-legends going offscreen

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -367,3 +367,13 @@ a .bg-color-none {
     width: 24px;
   }
 }
+
+@media screen and (max-width: 640px) {
+  .maplibregl-ctrl-bottom-right,
+  .maplibregl-ctrl-bottom-left {
+    position: fixed !important;
+  }
+  .maplibregl-ctrl-bottom-left {
+    bottom: 50px !important;
+  }
+}


### PR DESCRIPTION
As you can see in the screenshot below, it looks fine and not overflown anymore

Additionally
+ I fixed the **overlapping of copyright (i)  (when opened) with bottom-left legend** on map by raising the position of bottom-left legend a bit only on mobile

![image](https://github.com/CodeForPhilly/clean-and-green-philly/assets/93607971/ded44ead-9073-4184-b9db-12e60bb8afda)


solves #598 