### PR TITLE
604 /  Apply Hover Styling on Property Cards when Keyboard Focus is on Cards

### DIFF
--- a/src/components/PropertyCard.tsx
+++ b/src/components/PropertyCard.tsx
@@ -41,7 +41,7 @@ const PropertyCard = ({ feature, setSelectedProperty }: PropertyCardProps) => {
         className="cursor-pointer max-w-sm w-full h-full"
         onClick={handleClick}
       >
-        <div className="bg-white h-full flex flex-col rounded-lg overflow-hidden p-3 hover:bg-gray-100">
+        <div className="bg-white h-full flex flex-col rounded-lg overflow-hidden p-3 hover:bg-gray-100 focus-within:bg-gray-100">
           <div
             className="relative w-full rounded-md overflow-hidden"
             style={{ height: "160px", width: "auto" }}
@@ -55,7 +55,10 @@ const PropertyCard = ({ feature, setSelectedProperty }: PropertyCardProps) => {
             />
           </div>
           <div className="my-3">
-            <button className="font-bold heading-lg" onKeyDown={handleKeyDown}>
+            <button
+              className="font-bold heading-lg focus:bg-gray-100"
+              onKeyDown={handleKeyDown}
+            >
               {formattedAddress}
             </button>
             <div className="text-gray-700 body-sm">


### PR DESCRIPTION
Now, when a user is on the Find Properties page and uses their keyboard to tab to focus on a specific card, the background of the entire card will change to gray similar to hovering over the card with a mouse. Previously the background remained white. 

With change:
![Screenshot 2024-05-21 at 2 33 24 PM](https://github.com/CodeForPhilly/clean-and-green-philly/assets/111008425/ea1e2000-ec89-4509-b73f-1db3dd47dc4a)
