### PR TITLE
624: Add aria label to Saved button

### DIFF
--- a/src/components/SidePanelControlBar.tsx
+++ b/src/components/SidePanelControlBar.tsx
@@ -105,6 +105,7 @@ const SearchBarComponent: FC<SidePanelControlBarProps> = ({
           {savedPropertyCount > 0 ? (
             <ThemeButton
               color="tertiary"
+              aria-label="Saved Properties"
               label={
                 <div className="lg:space-x-1 body-md">
                   <span className="max-lg:hidden">Saved</span>


### PR DESCRIPTION
## Description

This PR adds an aria label "Saved Properties" to the Saved button in the map dashboard's side panel.

Closes #624 