### PR TITLE
Lebovits/add negligent devs

### DIFF
--- a/data/src/constants/services.py
+++ b/data/src/constants/services.py
@@ -41,7 +41,7 @@ DRUGCRIME_SQL_QUERY = f"SELECT text_general_code, dispatch_date, point_x AS x, p
 
 DELINQUENCIES_QUERY = "SELECT * FROM real_estate_tax_delinquencies"
 
-OPA_PROPERTIES_QUERY = "SELECT market_value, sale_date, sale_price, parcel_number, the_geom FROM opa_properties_public"
+OPA_PROPERTIES_QUERY = "SELECT market_value, sale_date, sale_price, parcel_number, mailing_address_1, mailing_address_2, mailing_care_of, mailing_street, mailing_zip, mailing_city_state, the_geom FROM opa_properties_public"
 
 UNSAFE_BUILDINGS_QUERY = "SELECT * FROM unsafe"
 

--- a/data/src/data_utils/city_owned_properties.py
+++ b/data/src/data_utils/city_owned_properties.py
@@ -11,17 +11,26 @@ def city_owned_properties(primary_featurelayer):
 
     city_owned_properties.gdf.dropna(subset=["opabrt"], inplace=True)
 
-    primary_featurelayer.opa_join(
-        city_owned_properties.gdf,
-        "opabrt",
-    )
+    primary_featurelayer.opa_join(city_owned_properties.gdf, "opabrt")
 
     rename_columns = {
         "agency": "city_owner_agency",
         "sideyardeligible": "side_yard_eligible",
     }
-
     primary_featurelayer.gdf.rename(columns=rename_columns, inplace=True)
+    
+    primary_featurelayer.gdf.loc[primary_featurelayer.gdf['owner_1'].isin(["PHILADELPHIA HOUSING AUTH", "PHILADELPHIA LAND BANK", "REDEVELOPMENT AUTHORITY", "PHILA REDEVELOPMENT AUTH"]), 'city_owner_agency'] = primary_featurelayer.gdf["owner_1"].replace({
+        "PHILADELPHIA HOUSING AUTH": "PHA",
+        "PHILADELPHIA LAND BANK": "Land Bank (PHDC)",
+        "REDEVELOPMENT AUTHORITY": "PRA",
+        "PHILA REDEVELOPMENT AUTH": "PRA"
+    })
+
+    primary_featurelayer.gdf.loc[
+        (primary_featurelayer.gdf['owner_1'] == "CITY OF PHILA") & 
+        (primary_featurelayer.gdf['owner_2'].str.contains("PUBLIC PROP|PUBLC PROP", na=False)), 
+        'city_owner_agency'
+    ] = "DPP"
 
     primary_featurelayer.gdf["side_yard_eligible"].fillna("No", inplace=True)
 

--- a/data/src/data_utils/city_owned_properties.py
+++ b/data/src/data_utils/city_owned_properties.py
@@ -31,6 +31,12 @@ def city_owned_properties(primary_featurelayer):
         (primary_featurelayer.gdf['owner_2'].str.contains("PUBLIC PROP|PUBLC PROP", na=False)), 
         'city_owner_agency'
     ] = "DPP"
+    
+    primary_featurelayer.gdf.loc[
+        primary_featurelayer.gdf['owner_1'].isin(["CITY OF PHILADELPHIA", "CITY OF PHILA"]) & 
+        primary_featurelayer.gdf['owner_2'].isna(), 
+        'city_owner_agency'
+    ] = "City of Philadelphia"
 
     primary_featurelayer.gdf["side_yard_eligible"].fillna("No", inplace=True)
 

--- a/data/src/data_utils/negligent_devs.py
+++ b/data/src/data_utils/negligent_devs.py
@@ -2,10 +2,11 @@ import geopandas as gpd
 
 
 def negligent_devs(primary_featurelayer):
+    
     devs = primary_featurelayer.gdf
     
     devs = devs[devs['city_owner_agency'].isna()]
-
+    
     devs['full_mailing_address'] = (
         devs['mailing_address_1'].str.strip() + ', ' +
         devs['mailing_street'].str.strip() + ', ' +
@@ -19,8 +20,6 @@ def negligent_devs(primary_featurelayer):
 
     sorted_address_counts = address_counts.sort_values(by='property_count', ascending=False)
 
-    print(sorted_address_counts.head(20))
-
     devs = devs.merge(sorted_address_counts, on='standardized_address', how='left')
 
     primary_featurelayer.gdf = primary_featurelayer.gdf.merge(
@@ -32,14 +31,5 @@ def negligent_devs(primary_featurelayer):
     primary_featurelayer.gdf.rename(columns={'property_count': 'n_properties_owned'}, inplace=True)
 
     primary_featurelayer.gdf['negligent_dev'] = primary_featurelayer.gdf['n_properties_owned'] > 5
-
-    print(primary_featurelayer.gdf)
-    
-    # print 10 cases where negligent_dev is True
-    print(primary_featurelayer.gdf[primary_featurelayer.gdf['negligent_dev']].head(10))
-
-    print(primary_featurelayer.gdf['negligent_dev'].sum())
-
-    print(primary_featurelayer.gdf['n_properties_owned'].max())
 
     return primary_featurelayer

--- a/data/src/data_utils/negligent_devs.py
+++ b/data/src/data_utils/negligent_devs.py
@@ -1,0 +1,45 @@
+import geopandas as gpd
+
+
+def negligent_devs(primary_featurelayer):
+    devs = primary_featurelayer.gdf
+    
+    devs = devs[devs['city_owner_agency'].isna()]
+
+    devs['full_mailing_address'] = (
+        devs['mailing_address_1'].str.strip() + ', ' +
+        devs['mailing_street'].str.strip() + ', ' +
+        devs['mailing_city_state'].str.strip() + ', ' +
+        devs['mailing_zip'].str.strip()
+    )
+
+    devs['standardized_address'] = devs['full_mailing_address'].str.lower().str.strip()
+
+    address_counts = devs.groupby('standardized_address').size().reset_index(name='property_count')
+
+    sorted_address_counts = address_counts.sort_values(by='property_count', ascending=False)
+
+    print(sorted_address_counts.head(20))
+
+    devs = devs.merge(sorted_address_counts, on='standardized_address', how='left')
+
+    primary_featurelayer.gdf = primary_featurelayer.gdf.merge(
+        devs[['opa_id', 'property_count']], 
+        on='opa_id', 
+        how='left'
+    )
+
+    primary_featurelayer.gdf.rename(columns={'property_count': 'n_properties_owned'}, inplace=True)
+
+    primary_featurelayer.gdf['negligent_dev'] = primary_featurelayer.gdf['n_properties_owned'] > 5
+
+    print(primary_featurelayer.gdf)
+    
+    # print 10 cases where negligent_dev is True
+    print(primary_featurelayer.gdf[primary_featurelayer.gdf['negligent_dev']].head(10))
+
+    print(primary_featurelayer.gdf['negligent_dev'].sum())
+
+    print(primary_featurelayer.gdf['n_properties_owned'].max())
+
+    return primary_featurelayer

--- a/data/src/data_utils/opa_properties.py
+++ b/data/src/data_utils/opa_properties.py
@@ -12,6 +12,12 @@ def opa_properties(primary_featurelayer):
             "sale_date",
             "sale_price",
             "parcel_number",
+            "mailing_address_1", 
+            "mailing_address_2", 
+            "mailing_care_of", 
+            "mailing_city_state",
+            "mailing_street",
+            "mailing_zip"
         ]
     )
 

--- a/data/src/script.py
+++ b/data/src/script.py
@@ -2,7 +2,6 @@ import sys
 
 from classes.backup_archive_database import BackupArchiveDatabase
 from classes.diff_report import DiffReport
-from config.config import FORCE_RELOAD, tiles_file_id_prefix
 from config.psql import conn
 from data_utils.access_process import access_process
 from data_utils.city_owned_properties import city_owned_properties
@@ -17,6 +16,7 @@ from data_utils.imm_dang_buildings import imm_dang_buildings
 from data_utils.l_and_i import l_and_i
 from data_utils.llc_owner import llc_owner
 from data_utils.nbhoods import nbhoods
+from data_utils.negligent_devs import negligent_devs
 from data_utils.opa_properties import opa_properties
 from data_utils.park_priority import park_priority
 from data_utils.phs_properties import phs_properties
@@ -28,7 +28,7 @@ from data_utils.tree_canopy import tree_canopy
 from data_utils.unsafe_buildings import unsafe_buildings
 from data_utils.vacant_properties import vacant_properties
 
-from config.config import FORCE_RELOAD
+from config.config import FORCE_RELOAD, tiles_file_id_prefix
 
 # Ensure the directory containing awkde is in the Python path
 awkde_path = "/usr/src/app"
@@ -56,6 +56,7 @@ services = [
     ppr_properties,
     contig_neighbors,
     dev_probability,
+    negligent_devs,
 ]
 
 # backup sql schema if we are reloading data


### PR DESCRIPTION
Identify negligent developers by grouping and counting by mailing address. Add a column with the number of total properties registered to a given mailing address, and a second column that sets negligent_dev == True if the number of properties > 5. (This is a bit arbitrary--can adjust.)