### PR TITLE
629: Limit Search to Philadelphia

### DIFF
--- a/src/components/PropertyMap.tsx
+++ b/src/components/PropertyMap.tsx
@@ -302,6 +302,15 @@ const PropertyMap: FC<PropertyMapProps> = ({
         const center = map.getCenter();
         geocoderRef.current = new MapboxGeocoder({
           accessToken: mapboxAccessToken,
+          bbox: [-75.288283,39.864114,-74.945063,40.140129],
+          filter: function (item) {
+            return item.context.some((i) => {
+                return (
+                    (i.id.split('.').shift() === 'place' && i.text === 'Philadelphia') ||
+                    (i.id.split('.').shift() === 'district' && i.text === 'Philadelphia County')
+                );
+            });
+          },
           mapboxgl: mapboxgl,
           marker: false,
           proximity: {


### PR DESCRIPTION
This PR adds a bounding box and filter to the mapbox geocoder to limit search results to addresses located in Philadelphia.

The filter limits search results to items that have a place feature of 'Philadelphia' or a district feature of 'Philadelphia County'.  The bounding box limits search results to a rectangular area around Philadelphia, PA so that the search doesn't return results from other places named Philadelphia, such as Philadelphia, Mississippi.

This closes issue #629 

![image](https://github.com/CodeForPhilly/clean-and-green-philly/assets/140654473/be9aa2cf-5e1e-42c0-b22a-a12b05c36ef7)
