### PR TITLE
654: Announce Number of Filters & 627: Keep Keyboard Focus on Filter Button

### DIFF
--- a/src/components/SidePanelControlBar.tsx
+++ b/src/components/SidePanelControlBar.tsx
@@ -103,8 +103,7 @@ const SearchBarComponent: FC<SidePanelControlBarProps> = ({
           )}
           <ThemeButton
             color="tertiary"
-            aria-label={filterCount === 0 ? "Filter Button" : `Filter Button ${filterCount} filters active`}
-            aria-roledescription=' '
+            aria-label={filterCount === 0 ? "Filter" : `Filter ${filterCount} filters active`}
             label={
               <div className="lg:space-x-1 body-md">
                 <span className="max-lg:hidden">Filter</span>

--- a/src/components/SidePanelControlBar.tsx
+++ b/src/components/SidePanelControlBar.tsx
@@ -103,20 +103,16 @@ const SearchBarComponent: FC<SidePanelControlBarProps> = ({
           )}
           <ThemeButton
             color="tertiary"
-            aria-label="Filter"
+            aria-roledescription=' '
             label={
               <div className="lg:space-x-1 body-md">
                 <span className="max-lg:hidden">Filter</span>
-                {filterCount !== 0 && <span>({filterCount})</span>}
+                <span className="sr-only">Button</span>
+                {filterCount !== 0 && <span aria-hidden="true">({filterCount})</span>}
+                {filterCount !== 0 && <span className="sr-only">{filterCount} filters applied</span>}
               </div>
             }
-            onPress={() => {
-              if (filterRef.current && currentView === "filter") {
-                filterRef.current.blur();
-              }
-
-              updateCurrentView("filter");
-            }}
+            onPress={() => updateCurrentView("filter")}
             isSelected={currentView === "filter" || filterCount !== 0}
             startContent={<Funnel />}
             className="max-lg:min-w-[4rem]"

--- a/src/components/SidePanelControlBar.tsx
+++ b/src/components/SidePanelControlBar.tsx
@@ -103,13 +103,12 @@ const SearchBarComponent: FC<SidePanelControlBarProps> = ({
           )}
           <ThemeButton
             color="tertiary"
+            aria-label={filterCount === 0 ? "Filter Button" : `Filter Button ${filterCount} filters active`}
             aria-roledescription=' '
             label={
               <div className="lg:space-x-1 body-md">
                 <span className="max-lg:hidden">Filter</span>
-                <span className="sr-only">Button</span>
                 {filterCount !== 0 && <span aria-hidden="true">({filterCount})</span>}
-                {filterCount !== 0 && <span className="sr-only">{filterCount} filters applied</span>}
               </div>
             }
             onPress={() => updateCurrentView("filter")}


### PR DESCRIPTION
This PR addresses issues #654 and #627 

For issue 654:
Two screen-reader-only spans have been added to the filter button label so that a screen reader can announce the filter button with the number of filters currently applied.  When no filters are applied it announces 'Filter button'.  When 2 filters are applied, it announces 'Filter button 2 filters applied'.  To allow the screen reader to read the label in that order, the aria-label property was removed and the default 'Button' announcement is overridden by adding `aria-roledescription=' '`

For issue 627:
The 'if' statement has been removed from the filtuer button's onPress function so that the focus stays on the filter button when filter view is toggled off.

To test:
- go to the Find Properties page
- using a screen reader, TAB to the Filter button, which will be announced as 'filter button'
- hit SPACE or ENTER to enter the filter view
- select one or more filter categories
- SHIFT+TAB back to the filter button, which will be announced as 'filter button [#] filters applied current' (Note: the word 'current' included in the announcement is the subject of issue 625)
- test focus with [screen reader key]+TAB, which will announce 'filter button [#] filters applied focused current'
- hit SPACE or ENTER to exit filter view
- test focus again with [screen reader key]+TAB, which will again announce 'filter button [#] filters applied focused current

Note:  If one of the active filters is a panel in the 'Get Access' section and you tab back into the filter view, the panel will not appear selected, although though the filter will still be active.  This is a bug being addressed by issue 685