### PR TITLE
Issue 698: Add a11y page

### DIFF
--- a/src/app/(content-pages)/accessibility-statement/AccessibilityStatementPage.tsx
+++ b/src/app/(content-pages)/accessibility-statement/AccessibilityStatementPage.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 export default function AccessibilityStatementPage() {
   return (
     <>
@@ -109,11 +111,10 @@ export default function AccessibilityStatementPage() {
       </p>
       <h2 className="heading-2xl font-semibold mt-8">Evaluation Report</h2>
       <p>
-        {" "}
-        You can find our full evaluation report in VPAT®️ format. (
-        <a href="" className="text-blue-400 underline">
+        You can find our full evaluation report in VPAT®️ format.(
+        <Link href="/vpat" className="text-blue-400 underline">
           link
-        </a>
+        </Link>
         )
       </p>
       <hr className="my-6 border-gray-300" />

--- a/src/app/(content-pages)/accessibility-statement/AccessibilityStatementPage.tsx
+++ b/src/app/(content-pages)/accessibility-statement/AccessibilityStatementPage.tsx
@@ -49,7 +49,9 @@ export default function AccessibilityStatementPage() {
           Submit an issue through our{" "}
           <a
             href="https://github.com/CodeForPhilly/clean-and-green-philly/issues"
-            className="text-blue-400 underline"
+            className="link"
+            target="_blank"
+            rel="noopener noreferrer"
           >
             Github
           </a>
@@ -111,8 +113,8 @@ export default function AccessibilityStatementPage() {
       </p>
       <h2 className="heading-2xl font-semibold mt-8">Evaluation Report</h2>
       <p>
-        You can find our full evaluation report in VPAT®️ format.(
-        <Link href="/vpat" className="text-blue-400 underline">
+        You can find our full evaluation report in VPAT®️ format. (
+        <Link href="/vpat" className="link">
           link
         </Link>
         )

--- a/src/app/(content-pages)/accessibility-statement/AccessibilityStatementPage.tsx
+++ b/src/app/(content-pages)/accessibility-statement/AccessibilityStatementPage.tsx
@@ -1,0 +1,124 @@
+export default function AccessibilityStatementPage() {
+  return (
+    <>
+      <h1 className="heading-3xl font-bold mb-6">
+        Accessibility at Clean & Green Philly
+      </h1>
+      <p>
+        Clean & Green Philly makes accessibility a priority. Our dedicated team
+        of volunteers is committed to creating accessible & inclusive
+        experiences for all. We believe that everyone should have the
+        opportunity to participate and use our website, regardless of their
+        physical or cognitive abilities.
+      </p>
+      <h2 className="heading-2xl font-semibold mt-8">
+        Measures to support accessibility
+      </h2>
+      <p>Our team prioritizes accessibility by:</p>
+      <ul className="list-disc ml-8 my-2">
+        <li>
+          Integrating accessibility as part of the design process Integrating
+        </li>
+        <li>accessibility in the development process Utilizing automated</li>
+        <li>accessibility tools as part of our testing Designating an</li>
+        <li>
+          Accessibility Specialist that serves as a resource for our
+          contributors
+        </li>
+      </ul>
+      <h2 className="heading-2xl font-semibold mt-8">Conformance Status</h2>
+      <p>
+        The Clean & Green Philly website has been evaluated using the Web
+        Content Accessibility Guidelines (WCAG) 2.2 for Level AA conformance.
+        While we strive for full accessibility, the site is currently partially
+        conformant with WCAG 2.2 Level AA, meaning some aspects of the content
+        do not yet fully meet these standards.
+      </p>
+      <h2 className="heading-2xl font-semibold mt-8"> Feedback & Contact</h2>
+      <p>
+        We welcome your feedback on any accessibility issues you may encounter,
+        or any questions. you may have about the accessibility of this website.
+        We appreciate your input on improving our services. We can be reached
+        at:
+      </p>
+      <ul className="list-disc ml-8 my-2">
+        <li>cleanandgreenphl@gmail.com</li>
+        <li>
+          Submit an issue through our{" "}
+          <a
+            href="https://github.com/CodeForPhilly/clean-and-green-philly/issues"
+            className="text-blue-400 underline"
+          >
+            Github
+          </a>
+        </li>
+      </ul>
+      <h2 className="heading-2xl font-semibold mt-8">Compatibility</h2>
+      <p>
+        Clean and Green Philly is compatible and tested with the latest version
+        of modern browsers and the following assistive technologies:
+      </p>
+      <ul className="list-disc ml-8 my-2">
+        <li>Safari with VoiceOver on Mac OS </li>
+        <li>
+          Mozilla Firefox, Google Chrome, Microsoft Edge with NVDA on Windows
+        </li>
+        <li> Google Chrome, Microsoft Edge with JAWS 2024 on Windows</li>
+      </ul>
+      <p>
+        At the time of this writing, Clean and Green Philly website has not been
+        tested on mobile devices.
+      </p>
+      <h2 className="heading-2xl font-semibold mt-8">
+        Limitations & Alternatives
+      </h2>
+      <p>
+        While Clean and Green Philly constantly aims to ensure accessibility of
+        our web pages, there are currently some limitations:
+      </p>
+      <ol className="list-decimal ml-8 my-2">
+        <li>
+          <span className="font-bold">Find Property Filters</span>: While it is
+          usable, the overall screen reader experience of selecting, deselecting
+          and clearing of filter options isn’t optimized. We currently have open
+          issues to resolve this.
+        </li>
+        <li>
+          <span className="font-bold">Announcing change of state</span>: Find
+          Property filters and pagination may not always announce the change,
+          such as if a new content has loaded, or when an option has been
+          removed.
+        </li>
+        <li>
+          <span className="font-bold">Interactive Map</span>: Despite our best
+          efforts, some elements in our interactive maps, particularly the
+          properties, may not be fully accessible. Although we selected the most
+          accessible map library available, some criteria couldn’t be met
+          without compromising the essential purpose and meaning of what we
+          represent in the map. We are actively researching ways to enhance its
+          accessibility. In the meantime, we recommend using the property list
+          as an alternative.
+        </li>
+      </ol>
+      <p>
+        This project is an open-source initiative run by dedicated volunteers.
+        While we strive to address issues as quickly and thoroughly as possible,
+        our capacity is limited. We are committed to doing our best and greatly
+        appreciate your patience and understanding as we work within these
+        constraints.
+      </p>
+      <h2 className="heading-2xl font-semibold mt-8">Evaluation Report</h2>
+      <p>
+        {" "}
+        You can find our full evaluation report in VPAT®️ format. (
+        <a href="" className="text-blue-400 underline">
+          link
+        </a>
+        )
+      </p>
+      <hr className="my-6 border-gray-300" />
+
+      <p>This statement was created on June 10, 2024.</p>
+    </>
+  );
+}

--- a/src/app/(content-pages)/accessibility-statement/layout.tsx
+++ b/src/app/(content-pages)/accessibility-statement/layout.tsx
@@ -1,0 +1,12 @@
+export const metadata = {
+  title: "Accessibility Statement",
+};
+
+const AccessibilityStatementLayout = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  return <>{children}</>;
+};
+export default AccessibilityStatementLayout;

--- a/src/app/(content-pages)/accessibility-statement/page.tsx
+++ b/src/app/(content-pages)/accessibility-statement/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { NextUIProvider } from "@nextui-org/react";
+import { FC } from "react";
+import AccessibilityStatementPage from "./AccessibilityStatementPage";
+
+const LegalDisclaimer: FC = () => {
+  return (
+    <NextUIProvider>
+      <AccessibilityStatementPage />
+    </NextUIProvider>
+  );
+};
+
+export default LegalDisclaimer;

--- a/src/app/(content-pages)/accessibility-statement/page.tsx
+++ b/src/app/(content-pages)/accessibility-statement/page.tsx
@@ -4,7 +4,7 @@ import { NextUIProvider } from "@nextui-org/react";
 import { FC } from "react";
 import AccessibilityStatementPage from "./AccessibilityStatementPage";
 
-const LegalDisclaimer: FC = () => {
+const AccessibilityStatement: FC = () => {
   return (
     <NextUIProvider>
       <AccessibilityStatementPage />
@@ -12,4 +12,4 @@ const LegalDisclaimer: FC = () => {
   );
 };
 
-export default LegalDisclaimer;
+export default AccessibilityStatement;

--- a/src/app/(content-pages)/vpat/VPATPage.tsx
+++ b/src/app/(content-pages)/vpat/VPATPage.tsx
@@ -1,0 +1,2026 @@
+export default function VPATPage() {
+  return (
+    <>
+      <h1 className="text-3xl font-bold mb-6">
+        Accessibility Conformance Report
+      </h1>
+      <h2 className="text-2xl font-semibold my-4">Product Information</h2>
+      <p className="mb-1">
+        <strong>Name of Product/Version:</strong> Clean & Green Philly
+      </p>
+      <p className="mb-1">
+        <strong>Report Date:</strong> May 31, 2024
+      </p>
+      <p className="mb-1">
+        <strong>
+          Product Description: Free and easy to use online tool empowering
+          community groups in Philadelphia to combat gun violence through the
+          revitalization of vacant properties via cleaning and greening
+          initiatives.
+        </strong>
+      </p>
+      <p className="mb-1">
+        <strong>Contact Information:</strong>{" "}
+        <ul className="list-disc ml-8 my-2">
+          <li>
+            {" "}
+            <a href="mailto:cleanandgreenphl@gmail.com" className="underline">
+              cleanandgreenphl@gmail.com
+            </a>
+          </li>
+        </ul>
+      </p>
+      <p className="mb-1">
+        <strong>Notes:</strong> This report is done on May 31, 2024 version of
+        the website. It has not been evaluated for mobile devices.
+      </p>
+      <p className="mb-1">
+        <strong>Evaluation Methods Used:</strong>
+        <ul className="list-disc ml-8 my-2">
+          <li>
+            The website is tested using automated accessibility checkers and
+            manual testing by accessibility specialists. It was tested on
+            desktop computers running Windows 10, and the latest version of Mac
+            OS. We evaluated using the latest version of supported browsers
+            Safari, Google Chrome, Mozilla Firefox & Microsoft Edge. We
+            performed keyboard-only tests and screen readers, including Voice
+            Over with Safari on Mac OS, the latest version of NVDA with Firefox
+            and Edge, and JAWS 2024 with Chrome and Edge on Windows OS.
+          </li>
+        </ul>
+      </p>
+      <p className="mb-1">
+        <strong>Applicable Standards/Guidelines</strong>:
+      </p>
+      <p>
+        {" "}
+        This report covers the degree of conformance for the following
+        accessibility standard/guidelines:
+      </p>
+      <table className="min-w-full bg-white border-collapse my-4">
+        <thead>
+          <tr>
+            <th className="border px-4 py-2 text-left w-1/2">
+              Standard/Guideline
+            </th>
+            <th className="border px-4 py-2 text-left w-1/2">
+              Included In Report
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="border px-4 py-2 w-1/2">
+              <a
+                href="https://www.w3.org/TR/2008/REC-WCAG20-20081211/"
+                className="underline"
+              >
+                Web Content Accessibility Guidelines 2.0
+              </a>
+            </td>
+            <td className="border px-4 py-2 w-1/2">
+              Level A (Yes)
+              <br />
+              Level AA (Yes)
+              <br />
+              Level AAA (No)
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/2">
+              <a href="https://www.w3.org/TR/WCAG21/" className="underline">
+                Web Content Accessibility Guidelines 2.1
+              </a>
+            </td>
+            <td className="border px-4 py-2 w-1/2">
+              Level A (Yes)
+              <br />
+              Level AA (Yes)
+              <br />
+              Level AAA (No)
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/2">
+              <a href="https://www.w3.org/TR/WCAG22/" className="underline">
+                Web Content Accessibility Guidelines 2.2
+              </a>
+            </td>
+            <td className="border px-4 py-2 w-1/2">
+              Level A (Yes)
+              <br />
+              Level AA (Yes)
+              <br />
+              Level AAA (No)
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/2">
+              <a href="https://www.access-board.gov/ict/" className="underline">
+                Revised Section 508 standards published January 18, 2017 and
+                corrected January 22, 2018
+              </a>
+            </td>
+            <td className="border px-4 py-2 w-1/2">Yes</td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/2">
+              <a
+                href="https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.01.01_60/en_301549v030101p.pdf"
+                className="underline"
+              >
+                EN 301 549 Accessibility requirements for ICT products and
+                services - V3.1.1 (2019-11) AND EN 301 549 Accessibility
+                requirements for ICT products and services - V3.2.1 (2021-03)
+              </a>
+            </td>
+            <td className="border px-4 py-2 w-1/2">No</td>
+          </tr>
+        </tbody>
+      </table>
+      <p className="mb-1">
+        <strong>Terms</strong>
+        <p>
+          The terms used in the Conformance Level information are defined as
+          follows:
+        </p>
+        <ul className="list-disc ml-8 my-2">
+          <li>
+            <strong>Supports</strong>: The functionality of the product has at
+            least one method that meets the criterion without known defects or
+            meets with equivalent facilitation.
+          </li>
+          <li>
+            <strong>Partially Supports</strong>: Some functionality of the
+            product does not meet the criterion.
+          </li>
+          <li>
+            <strong>Does Not Support</strong>: The majority of product
+            functionality does not meet the criterion.
+          </li>
+          <li>
+            <strong>Not Applicable</strong>: The criterion is not relevant to
+            the product.
+          </li>
+          <li>
+            <strong>Not Evaluated</strong>: The product has not been evaluated
+            against the criterion. This can only be used in WCAG Level AAA
+            criteria.
+          </li>
+        </ul>
+      </p>
+      <h2 className="text-2xl font-semibold my-4" id="WCAG-2.2">
+        WCAG 2.2 Report
+      </h2>
+      <p className="mb-1">
+        Tables 1 and 2 also document conformance with:
+        <ul className="list-disc ml-8 my-2">
+          <li>
+            Revised Section 508: Chapter 5 – 501.1 Scope, 504.2 Content Creation
+            or Editing, and Chapter 6 – 602.3 Electronic Support Documentation.
+          </li>
+        </ul>
+      </p>
+      <p className="italic">
+        Note: When reporting on conformance with the WCAG 2.x Success Criteria,
+        they are scoped for full pages, complete processes, and
+        accessibility-supported ways of using technology as documented in the{" "}
+        <a
+          href="https://www.w3.org/TR/WCAG20/#conformance-reqs"
+          className="underline"
+        >
+          WCAG 2.0 Conformance Requirements
+        </a>
+        .
+      </p>
+      <h3 className="text-xl font-semibold my-2">
+        Table 1: Success Criteria, Level A
+      </h3>
+      <p className="mb-1">
+        Notes: This conformance report applies only to the website. The mobile
+        site has not been evaluated. We will periodically update this report as
+        we release fixes.
+      </p>
+      <table className="min-w-full bg-white border-collapse my-4">
+        <thead>
+          <tr>
+            <th className="border px-4 py-2 text-left w-1/3">Criteria</th>
+            <th className="border px-4 py-2 text-left w-1/3">
+              Conformance Level
+            </th>
+            <th className="border px-4 py-2 text-left w-1/3">
+              Remarks and Explanations
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#text-equiv-all"
+                className="underline"
+              >
+                <strong>1.1.1 Non-text Content</strong>
+              </a>{" "}
+              (Level A) <br />
+              Also applies to:
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>602.3 (Support Docs)</li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Partially supports</td>
+            <td className="border px-4 py-2 w-1/3">
+              The close button found on Property Filter pill shapes does not
+              have an accessible name.{" "}
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#media-equiv-av-only-alt"
+                className="underline"
+              >
+                <strong>1.2.1 Audio-only and Video-only (Prerecorded)</strong>
+              </a>{" "}
+              (Level A) <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>602.3 (Support Docs)</li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not Applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              There are currently no audio or video media in the website{" "}
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#media-equiv-captions"
+                className="underline"
+              >
+                <strong>1.2.2 Captions (Prerecorded)</strong>
+              </a>{" "}
+              (Level A) <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>602.3 (Support Docs)</li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not Applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              There are currently no audio or video media in the website{" "}
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc"
+                className="underline"
+              >
+                <strong>
+                  1.2.3 Audio Description or Media Alternative (Prerecorded)
+                </strong>
+              </a>{" "}
+              (Level A) <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>602.3 (Support Docs)</li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not Applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              There are currently no audio or video media in the website{" "}
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic"
+                className="underline"
+              >
+                <strong>1.3.1 Info and Relationships</strong>
+              </a>{" "}
+              (Level A) <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>602.3 (Support Docs)</li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Partially Supports</td>
+            <td className="border px-4 py-2 w-1/3">
+              Some elements found in the Find Properties page, such as the
+              filters, list box, & toggle buttons have known issues.{" "}
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#content-structure-separation-sequence"
+                className="underline"
+              >
+                <strong>1.3.2 Meaningful Sequence</strong>
+              </a>{" "}
+              (Level A) <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>602.3 (Support Docs)</li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Partially Supports</td>
+            <td className="border px-4 py-2 w-1/3">
+              Some links that take you to a specific position on a webpage are
+              not spot on.
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#content-structure-separation-understanding"
+                className="underline"
+              >
+                <strong>1.3.3 Sensory Characteristics</strong>
+              </a>{" "}
+              (Level A) <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>
+                  <strong>602.3 (Support Docs)</strong>
+                </li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-without-color"
+                className="underline"
+              >
+                <strong>1.4.1 Use of Color</strong>
+              </a>{" "}
+              (Level A) <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>
+                  <strong>602.3 (Support Docs)</strong>
+                </li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Partially Supports</td>
+            <td className="border px-4 py-2 w-1/3">
+              The interactive map currently depends on color to denote the
+              priority of properties. While we actively look for avenues to
+              remediate this, the Property list view serves as an alternative.
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-dis-audio"
+                className="underline"
+              >
+                <strong>1.4.2 Audio Control</strong>
+              </a>{" "}
+              (Level A) <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>
+                  <strong>602.3 (Support Docs)</strong>
+                </li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              There are currently no audio or video media in the website
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#keyboard-operation-keyboard-operable"
+                className="underline"
+              >
+                <strong>2.1.1 Keyboard</strong>
+              </a>{" "}
+              (Level A) <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>
+                  <strong>602.3 (Support Docs)</strong>
+                </li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Partially Supports</td>
+            <td className="border px-4 py-2 w-1/3">
+              The interactive map’s properties currently can’t be navigated by
+              keyboard. While we actively look for avenues to remediate this,
+              the Property list view serves as an alternative.
+            </td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#keyboard-operation-trapping"
+                className="underline"
+              >
+                <strong>2.1.2 No Keyboard Trap</strong>
+              </a>{" "}
+              (Level A) <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>
+                  <strong>602.3 (Support Docs)</strong>
+                </li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG21/#character-key-shortcuts"
+                className="underline"
+              >
+                <strong>2.1.4 Character Key Shortcuts</strong>
+              </a>{" "}
+              (Level A 2.1 and 2.2)
+              <br /> Revised Section 508 – Does not apply
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              The website does not require any special key shortcuts
+            </td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#time-limits-required-behaviors"
+                className="underline"
+              >
+                <strong>2.2.1 Timing Adjustable</strong>
+              </a>{" "}
+              (Level A) <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>
+                  <strong>602.3 (Support Docs)</strong>
+                </li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#time-limits-pause"
+                className="underline"
+              >
+                <strong>2.2.2 Pause, Stop, Hide</strong>
+              </a>{" "}
+              (Level A) <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>602.3 (Support Docs)</li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              There are currently no animation, audio or video media in the
+              website
+            </td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#seizure-does-not-violate"
+                className="underline"
+              >
+                <strong>2.3.1 Three Flashes or Below Threshold</strong>
+              </a>{" "}
+              (Level A) <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>
+                  <strong>602.3 (Support Docs)</strong>
+                </li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              There are currently no animation, or video media in the website
+            </td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip"
+                className="underline"
+              >
+                <strong>2.4.1 Bypass Blocks</strong>
+              </a>{" "}
+              (Level A) <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>
+                  <strong>
+                    602.3 (Support Docs) – Does not apply to non-web docs
+                  </strong>
+                </li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title"
+                className="underline"
+              >
+                <strong>2.4.2 Page Titled</strong>
+              </a>{" "}
+              (Level A) <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>
+                  <strong>602.3 (Support Docs)</strong>
+                </li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-order"
+                className="underline"
+              >
+                <strong>2.4.3 Focus Order</strong>
+              </a>{" "}
+              (Level A) <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>
+                  <strong>602.3 (Support Docs)</strong>
+                </li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Partially supports</td>
+            <td className="border px-4 py-2 w-1/3">
+              Interactive map have known issues; In the Find Properties page,
+              keyboard focus can get lost when toggling the Filter button;
+            </td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs"
+                className="underline"
+              >
+                <strong>2.4.4 Link Purpose (In Context)</strong>
+              </a>{" "}
+              (Level A) <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>
+                  <strong>602.3 (Support Docs)</strong>
+                </li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs"
+                className="underline"
+              >
+                <strong>2.4.4 Link Purpose (In Context)</strong>
+              </a>{" "}
+              (Level A) <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>
+                  <strong>602.3 (Support Docs)</strong>
+                </li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG21/#pointer-gestures"
+                className="underline"
+              >
+                <strong>2.5.1 Pointer Gestures</strong>
+              </a>{" "}
+              (Level A 2.1 and 2.2)
+              <br />
+              Revised Section 508 – Does not apply
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG21/#pointer-cancellation"
+                className="underline"
+              >
+                <strong>2.5.2 Pointer Cancellation</strong>
+              </a>{" "}
+              (Level A 2.1 and 2.2) <br />
+              Also applies to:
+              <br /> Revised Section 508 – Does not apply
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG21/#label-in-name"
+                className="underline"
+              >
+                <strong>2.5.3 Label in Name</strong>
+              </a>{" "}
+              (Level A 2.1 and 2.2) <br />
+              Also applies to:
+              <br /> Revised Section 508 – Does not apply
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG21/#motion-actuation"
+                className="underline"
+              >
+                <strong>2.5.4 Motion Actuation</strong>
+              </a>{" "}
+              (Level A)
+              <br /> Revised Section 508 – Does not apply
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#meaning-doc-lang-id"
+                className="underline"
+              >
+                <strong>3.1.1 Language of Page</strong>
+              </a>{" "}
+              (Level A)
+              <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>
+                  <strong>602.3 (Support Docs)</strong>
+                </li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#consistent-behavior-receive-focus"
+                className="underline"
+              >
+                <strong>3.2.1 On Focus</strong>
+              </a>{" "}
+              (Level A)
+              <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>
+                  <strong>602.3 (Support Docs)</strong>
+                </li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#consistent-behavior-unpredictable-change"
+                className="underline"
+              >
+                <strong>3.2.2 On Input</strong>
+              </a>{" "}
+              (Level A)
+              <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>
+                  <strong>602.3 (Support Docs)</strong>
+                </li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG22/#consistent-help"
+                className="underline"
+              >
+                <strong>3.2.6 Consistent Help</strong>
+              </a>{" "}
+              (Level A 2.2 only)
+              <br /> Revised Section 508 – Does not apply
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#minimize-error-identified"
+                className="underline"
+              >
+                <strong>3.3.1 Error Identification</strong>
+              </a>{" "}
+              (Level A)
+              <br />
+              Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>
+                  <strong>602.3 (Support Docs)</strong>
+                </li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Partially supports</td>
+            <td className="border px-4 py-2 w-1/3">
+              The interactive map’s search tool can be optimized.
+            </td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#minimize-error-cues"
+                className="underline"
+              >
+                <strong>3.3.2 Labels or Instructions</strong>
+              </a>{" "}
+              (Level A) <br />
+              Also applies to:
+              <br />
+              Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>
+                  <strong>602.3 (Support Docs)</strong>
+                </li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG22/#redundant-entry"
+                className="underline"
+              >
+                <strong>3.3.7 Redundant Entry</strong>
+              </a>{" "}
+              (Level A 2.2 only)
+              <br />
+              Revised Section 508 – Does not apply
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#ensure-compat-parses"
+                className="underline"
+              >
+                <strong>4.1.1 Parsing</strong>
+              </a>{" "}
+              (Level A)
+              <br />
+              Applies to:
+              <br />
+              WCAG 2.0 and 2.1 – Always answer ‘Supports’ WCAG 2.2 (obsolete and
+              removed) - Does not apply Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>
+                  <strong>602.3 (Support Docs)</strong>
+                </li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Does not apply</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#ensure-compat-rsv"
+                className="underline"
+              >
+                <strong>4.1.2 Name, Role, Value</strong>
+              </a>{" "}
+              (Level A)
+              <br />
+              Also applies to:
+              <br />
+              Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>
+                  <strong>602.3 (Support Docs)</strong>
+                </li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Partially supports</td>
+            <td className="border px-4 py-2 w-1/3">
+              Some elements found in the Find Properties page, such as the
+              filters, list box, toggle buttons & pagination does not announce
+              the change of state.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <h3 className="text-xl font-semibold my-2">
+        Table 2: Success Criteria, Level AA
+      </h3>
+      <p className="mb-1">
+        Notes: This conformance report applies only to the website. The mobile
+        site has not been evaluated. We will periodically update this report as
+        we release fixes.
+      </p>
+      <table className="min-w-full bg-white border-collapse my-4">
+        <thead>
+          <tr>
+            <th className="border px-4 py-2 text-left w-1/3">Criteria</th>
+            <th className="border px-4 py-2 text-left w-1/3">
+              Conformance Level
+            </th>
+            <th className="border px-4 py-2 text-left w-1/3">
+              Remarks and Explanations
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#media-equiv-real-time-captions"
+                className="underline"
+              >
+                <strong>1.2.4 Captions (Live)</strong>
+              </a>{" "}
+              (Level AA) <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>602.3 (Support Docs)</li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              There are currently no audio or video media in the website{" "}
+            </td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc-only"
+                className="underline"
+              >
+                <strong>1.2.5 Audio Description (Prerecorded)</strong>
+              </a>{" "}
+              (Level AA) <br />
+              Also applies to:
+              <br /> Revised Section 508
+              <ul className="list-disc ml-8">
+                <li>501 (Web)(Software)</li>
+                <li>504.2 (Authoring Tool)</li>
+                <li>602.3 (Support Docs)</li>
+              </ul>
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              There are currently no audio or video media in the website{" "}
+            </td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG21/#orientation"
+                className="underline"
+              >
+                <strong>1.3.4 Orientation</strong>
+              </a>{" "}
+              (Level AA 2.1 and 2.2) <br />
+              Also applies to:
+              <br /> Revised Section 508 – Does not apply
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                href="https://www.w3.org/TR/WCAG21/#identify-input-purpose"
+                className="underline"
+              >
+                <strong>1.3.5 Identify Input Purpose</strong>
+              </a>{" "}
+              (Level AA 2.1 and 2.2) <br />
+              Also applies to:
+              <br /> Revised Section 508 – Does not apply
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+        </tbody>
+
+        <tr>
+          <td className="border px-4 py-2 w-1/3">
+            <a
+              href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast"
+              className="underline"
+            >
+              <strong>1.4.3 Contrast (Minimum)</strong>
+            </a>{" "}
+            (Level AA) <br />
+            Also applies to:
+            <br /> Revised Section 508
+            <ul className="list-disc ml-8">
+              <li>501 (Web)(Software)</li>
+              <li>504.2 (Authoring Tool)</li>
+              <li>
+                <strong>602.3 (Support Docs)</strong>
+              </li>
+            </ul>
+          </td>
+          <td className="border px-4 py-2 w-1/3">Partially Supports</td>
+          <td className="border px-4 py-2 w-1/3">
+            The interactive map have colors that don’t pass the minimum
+            requirement. While we actively look for avenues to remediate this,
+            the Property list view serves as an alternative.
+          </td>
+        </tr>
+
+        <tr>
+          <td className="border px-4 py-2 w-1/3">
+            <a
+              href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-scale"
+              className="underline"
+            >
+              <strong>1.4.4 Resize text</strong>
+            </a>{" "}
+            (Level AA) <br />
+            Also applies to:
+            <br /> Revised Section 508
+            <ul className="list-disc ml-8">
+              <li>501 (Web)(Software)</li>
+              <li>504.2 (Authoring Tool)</li>
+              <li>
+                <strong>602.3 (Support Docs)</strong>
+              </li>
+            </ul>
+          </td>
+          <td className="border px-4 py-2 w-1/3">Supports</td>
+          <td className="border px-4 py-2 w-1/3"></td>
+        </tr>
+
+        <tr>
+          <td className="border px-4 py-2 w-1/3">
+            <a
+              href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-presentation"
+              className="underline"
+            >
+              <strong>1.4.5 Images of Text</strong>
+            </a>{" "}
+            (Level AA) <br />
+            Also applies to:
+            <br /> Revised Section 508
+            <ul className="list-disc ml-8">
+              <li>501 (Web)(Software)</li>
+              <li>504.2 (Authoring Tool)</li>
+              <li>
+                <strong>602.3 (Support Docs)</strong>
+              </li>
+            </ul>
+          </td>
+          <td className="border px-4 py-2 w-1/3">Partially Supports</td>
+          <td className="border px-4 py-2 w-1/3">
+            An image found in Transform page have an image of text.
+          </td>
+        </tr>
+
+        <tr>
+          <td className="border px-4 py-2 w-1/3">
+            <a
+              href="https://www.w3.org/TR/WCAG21/#reflow"
+              className="underline"
+            >
+              <strong>1.4.10 Reflow</strong>
+            </a>{" "}
+            (Level AA 2.1 and 2.2) <br />
+            Also applies to:
+            <br /> Revised Section 508 – Does not apply
+          </td>
+          <td className="border px-4 py-2 w-1/3">Supports</td>
+          <td className="border px-4 py-2 w-1/3"></td>
+        </tr>
+
+        <tr>
+          <td className="border px-4 py-2 w-1/3">
+            <a
+              href="https://www.w3.org/TR/WCAG21/#non-text-contrast"
+              className="underline"
+            >
+              <strong>1.4.11 Non-text Contrast</strong>
+            </a>{" "}
+            (Level AA 2.1 and 2.2)
+            <br /> Revised Section 508 – Does not apply
+          </td>
+          <td className="border px-4 py-2 w-1/3">Partially Supports</td>
+          <td className="border px-4 py-2 w-1/3">
+            The interactive map currently uses colors to denote the priority of
+            properties that are currently not optimal. While we actively look
+            for avenues to remediate this, the Property list view serves as an
+            alternative.
+          </td>
+        </tr>
+
+        <tr>
+          <td className="border px-4 py-2 w-1/3">
+            <a
+              href="https://www.w3.org/TR/WCAG21/#text-spacing"
+              className="underline"
+            >
+              <strong>1.4.12 Text Spacing</strong>
+            </a>{" "}
+            (Level AA 2.1 and 2.2)
+            <br />
+            Also applies to:
+            <br /> Revised Section 508 – Does not apply
+          </td>
+          <td className="border px-4 py-2 w-1/3">Supports</td>
+          <td className="border px-4 py-2 w-1/3"></td>
+        </tr>
+
+        <tr>
+          <td className="border px-4 py-2 w-1/3">
+            <a
+              href="https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus"
+              className="underline"
+            >
+              <strong>1.4.13 Content on Hover or Focus</strong>
+            </a>{" "}
+            (Level AA 2.1 and 2.2)
+            <br /> Revised Section 508 – Does not apply
+          </td>
+          <td className="border px-4 py-2 w-1/3">Supports</td>
+          <td className="border px-4 py-2 w-1/3"></td>
+        </tr>
+
+        <tr>
+          <td className="border px-4 py-2 w-1/3">
+            <a
+              href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc"
+              className="underline"
+            >
+              <strong>2.4.5 Multiple Ways</strong>
+            </a>{" "}
+            (Level AA)
+            <br /> Revised Section 508
+            <ul className="list-disc ml-8">
+              <li>501 (Web)(Software) – Does not apply to non-web software</li>
+              <li>504.2 (Authoring Tool)</li>
+              <li>
+                <strong>
+                  602.3 (Support Docs) – Does not apply to non-web docs
+                </strong>
+              </li>
+            </ul>
+          </td>
+          <td className="border px-4 py-2 w-1/3"></td>
+          <td className="border px-4 py-2 w-1/3"></td>
+        </tr>
+
+        <tr>
+          <td className="border px-4 py-2 w-1/3">
+            <a
+              href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc"
+              className="underline"
+            >
+              <strong>2.4.5 Multiple Ways</strong>
+            </a>{" "}
+            (Level AA)
+            <br /> Revised Section 508
+            <ul className="list-disc ml-8">
+              <li>501 (Web)(Software) – Does not apply to non-web software</li>
+              <li>504.2 (Authoring Tool)</li>
+              <li>
+                <strong>
+                  602.3 (Support Docs) – Does not apply to non-web docs
+                </strong>
+              </li>
+            </ul>
+          </td>
+          <td className="border px-4 py-2 w-1/3"></td>
+          <td className="border px-4 py-2 w-1/3"></td>
+        </tr>
+
+        <tr>
+          <td className="border px-4 py-2 w-1/3">
+            <a
+              href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive"
+              className="underline"
+            >
+              <strong>2.4.6 Headings and Labels</strong>
+            </a>{" "}
+            (Level AA) <br />
+            Also applies to:
+            <br /> Revised Section 508
+            <ul className="list-disc ml-8">
+              <li>501 (Web)(Software)</li>
+              <li>504.2 (Authoring Tool)</li>
+              <li>
+                <strong>602.3 (Support Docs)</strong>
+              </li>
+            </ul>
+          </td>
+          <td className="border px-4 py-2 w-1/3">Supports</td>
+          <td className="border px-4 py-2 w-1/3"></td>
+        </tr>
+
+        <tr>
+          <td className="border px-4 py-2 w-1/3">
+            <a
+              href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-visible"
+              className="underline"
+            >
+              <strong>2.4.7 Focus Visible</strong>
+            </a>{" "}
+            (Level AA) <br />
+            Also applies to:
+            <br /> Revised Section 508
+            <ul className="list-disc ml-8">
+              <li>501 (Web)(Software)</li>
+              <li>504.2 (Authoring Tool)</li>
+              <li>
+                <strong>602.3 (Support Docs)</strong>
+              </li>
+            </ul>
+          </td>
+          <td className="border px-4 py-2 w-1/3">Supports</td>
+          <td className="border px-4 py-2 w-1/3"></td>
+        </tr>
+
+        <tr>
+          <td className="border px-4 py-2 w-1/3">
+            <a
+              href="https://www.w3.org/TR/WCAG22/#focus-not-obscured-minimum"
+              className="underline"
+            >
+              <strong>2.4.11 Focus Not Obscured (Minimum)</strong>
+            </a>{" "}
+            (Level AA 2.2 only)
+            <br /> Revised Section 508 – Does not apply
+          </td>
+          <td className="border px-4 py-2 w-1/3">Supports</td>
+          <td className="border px-4 py-2 w-1/3"></td>
+        </tr>
+
+        <tr>
+          <td className="border px-4 py-2 w-1/3">
+            <a
+              href="https://www.w3.org/TR/WCAG22/#dragging-movements"
+              className="underline"
+            >
+              <strong>2.5.7 Dragging Movements</strong>
+            </a>{" "}
+            (Level AA 2.2 only)
+            <br /> Revised Section 508 – Does not apply
+          </td>
+          <td className="border px-4 py-2 w-1/3">Not applicable</td>
+          <td className="border px-4 py-2 w-1/3">
+            There are currently no draggable interactions found in the website.
+          </td>
+        </tr>
+
+        <tr>
+          <td className="border px-4 py-2 w-1/3">
+            <a
+              href="https://www.w3.org/TR/WCAG22/#target-size-minimum"
+              className="underline"
+            >
+              <strong>2.5.8 Target Size (Minimum)</strong>
+            </a>{" "}
+            (Level AA 2.2 only)
+            <br /> Revised Section 508 – Does not apply
+          </td>
+          <td className="border px-4 py-2 w-1/3">Supports</td>
+          <td className="border px-4 py-2 w-1/3"></td>
+        </tr>
+
+        <tr>
+          <td className="border px-4 py-2 w-1/3">
+            <a
+              href="https://www.w3.org/TR/WCAG20/#meaning-other-lang-id"
+              className="underline"
+            >
+              <strong>3.1.2 Language of Parts</strong>
+            </a>{" "}
+            (Level AA) <br />
+            Also applies to:
+            <br /> Revised Section 508
+            <ul className="list-disc ml-8">
+              <li>501 (Web)(Software)</li>
+              <li>504.2 (Authoring Tool)</li>
+              <li>
+                <strong>602.3 (Support Docs)</strong>
+              </li>
+            </ul>
+          </td>
+          <td className="border px-4 py-2 w-1/3">Not applicable</td>
+          <td className="border px-4 py-2 w-1/3"></td>
+        </tr>
+
+        <tr>
+          <td className="border px-4 py-2 w-1/3">
+            <a
+              href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-locations"
+              className="underline"
+            >
+              <strong>3.2.3 Consistent Navigation</strong>
+            </a>{" "}
+            (Level AA) <br />
+            Also applies to:
+            <br /> Revised Section 508
+            <ul className="list-disc ml-8">
+              <li>501 (Web)(Software) – Does not apply to non-web software</li>
+              <li>504.2 (Authoring Tool)</li>
+              <li>
+                <strong>
+                  602.3 (Support Docs) – Does not apply to non-web docs
+                </strong>
+              </li>
+            </ul>
+          </td>
+          <td className="border px-4 py-2 w-1/3">Supports</td>
+          <td className="border px-4 py-2 w-1/3"></td>
+        </tr>
+
+        <tr>
+          <td className="border px-4 py-2 w-1/3">
+            <a
+              href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-functionality"
+              className="underline"
+            >
+              <strong>3.2.4 Consistent Identification</strong>
+            </a>{" "}
+            (Level AA) <br />
+            Also applies to:
+            <br /> Revised Section 508
+            <ul className="list-disc ml-8">
+              <li>501 (Web)(Software) – Does not apply to non-web software</li>
+              <li>504.2 (Authoring Tool)</li>
+              <li>
+                <strong>
+                  602.3 (Support Docs) – Does not apply to non-web docs
+                </strong>
+              </li>
+            </ul>
+          </td>
+          <td className="border px-4 py-2 w-1/3">Supports</td>
+          <td className="border px-4 py-2 w-1/3"></td>
+        </tr>
+
+        <tr>
+          <td className="border px-4 py-2 w-1/3">
+            <a
+              href="https://www.w3.org/TR/WCAG20/#minimize-error-suggestions"
+              className="underline"
+            >
+              <strong>3.3.3 Error Suggestion</strong>
+            </a>{" "}
+            (Level AA)
+            <br /> Revised Section 508
+            <ul className="list-disc ml-8">
+              <li>501 (Web)(Software)</li>
+              <li>504.2 (Authoring Tool)</li>
+              <li>
+                <strong>602.3 (Support Docs)</strong>
+              </li>
+            </ul>
+          </td>
+          <td className="border px-4 py-2 w-1/3"></td>
+          <td className="border px-4 py-2 w-1/3"></td>
+        </tr>
+
+        <tr>
+          <td className="border px-4 py-2 w-1/3">
+            <a
+              href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible"
+              className="underline"
+            >
+              <strong>3.3.4 Error Prevention (Legal, Financial, Data)</strong>
+            </a>{" "}
+            (Level AA)
+            <br /> Revised Section 508
+            <ul className="list-disc ml-8">
+              <li>501 (Web)(Software)</li>
+              <li>504.2 (Authoring Tool)</li>
+              <li>
+                <strong>602.3 (Support Docs)</strong>
+              </li>
+            </ul>
+          </td>
+          <td className="border px-4 py-2 w-1/3">Not applicable</td>
+          <td className="border px-4 py-2 w-1/3"></td>
+        </tr>
+
+        <tr>
+          <td className="border px-4 py-2 w-1/3">
+            <a
+              href="https://www.w3.org/TR/WCAG22/#accessible-authentication-minimum"
+              className="underline"
+            >
+              <strong>3.3.8 Accessible Authentication (Minimum)</strong>
+            </a>{" "}
+            (Level AA 2.2 only)
+            <br /> Revised Section 508 – Does not apply
+          </td>
+          <td className="border px-4 py-2 w-1/3">Not applicable</td>
+          <td className="border px-4 py-2 w-1/3"></td>
+        </tr>
+
+        <tr>
+          <td className="border px-4 py-2 w-1/3">
+            <a
+              href="https://www.w3.org/TR/WCAG21/#status-messages"
+              className="underline"
+            >
+              <strong>4.1.3 Status Messages</strong>
+            </a>{" "}
+            (Level AA 2.1 and 2.2)
+            <br /> Revised Section 508 – Does not apply
+          </td>
+          <td className="border px-4 py-2 w-1/3">Partially supports</td>
+          <td className="border px-4 py-2 w-1/3">
+            We currently don’t announce the change of state on some behaviors
+            found on the Find Properties page, such as the pagination and when
+            properties yield no results.
+          </td>
+        </tr>
+      </table>
+      <h2 className="text-2xl font-semibold my-4 bg-zinc-200">
+        Revised Section 508 Report
+      </h2>
+      <p className="mb-1">
+        Notes: This conformance report applies only to the website. The mobile
+        site has not been evaluated. We will periodically update this report as
+        we release fixes.
+      </p>
+      <h3 className="text-xl font-semibold my-2">
+        Chapter 3:{" "}
+        <a
+          href="https://www.access-board.gov/ict/#chapter-3-functional-performance-criteria"
+          className="underline"
+        >
+          {" "}
+          Functional Performance Criteria
+        </a>{" "}
+        (FPC)
+      </h3>
+      <p className="mb-1">
+        Notes: The interactive map needs better accessibility support and
+        optimization. We are actively looking to improve this.
+      </p>
+      <table className="min-w-full bg-white border-collapse my-4">
+        <thead>
+          <tr>
+            <th className="border px-4 py-2 text-left w-1/3">Criteria</th>
+            <th className="border px-4 py-2 text-left w-1/3">
+              Conformance Level
+            </th>
+            <th className="border px-4 py-2 text-left w-1/3">
+              Remarks and Explanations
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">302.1 Without Vision</td>
+            <td className="border px-4 py-2 w-1/3">Partially supports</td>
+            <td className="border px-4 py-2 w-1/3">
+              The interactive map current doesn’t support keyboard navigation to
+              the properties. While we actively look for avenues to remediate
+              this, the Property list view serves as an alternative.
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              302.2 With Limited Vision
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              302.3 Without Perception of Color
+            </td>
+            <td className="border px-4 py-2 w-1/3">Partially supports</td>
+            <td className="border px-4 py-2 w-1/3">
+              The interactive map currently depends on color to denote the
+              priority of properties. While we actively look for avenues to
+              remediate this, the Property list view serves as an alternative.
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">302.4 Without Hearing</td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              There are currently no audio or video media in the website
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              302.5 With Limited Hearing
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              There are currently no audio or video media in the website
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">302.6 Without Speech</td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              No speech input required in the website
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              302.7 With Limited Manipulation
+            </td>
+            <td className="border px-4 py-2 w-1/3">Partially supports</td>
+            <td className="border px-4 py-2 w-1/3">
+              The interactive map current doesn’t support keyboard navigation to
+              the properties. While we actively look for avenues to remediate
+              this, the Property list view serves as an alternative.
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              302.8 With Limited Reach and Strength
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              302.9 With Limited Language, Cognitive, and Learning Abilities
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+        </tbody>
+      </table>
+      <h3 className="text-xl font-semibold my-2">
+        Section 508 Chapter 4:{" "}
+        <a
+          href="https://www.access-board.gov/ict/#chapter-4-hardware"
+          className="underline"
+        >
+          Hardware
+        </a>
+      </h3>
+      <p className="mb-1">
+        Notes: Not applicable to Clean & Green Philly website.
+      </p>
+
+      <h3 className="text-xl font-semibold my-2">
+        {" "}
+        Chapter 5:{" "}
+        <a
+          href="https://www.access-board.gov/ict/#chapter-5-software"
+          className="underline"
+        >
+          Software
+        </a>
+      </h3>
+      <p className="mb-1">Notes:</p>
+      <table className="min-w-full bg-white border-collapse my-4">
+        <thead>
+          <tr>
+            <th className="border px-4 py-2 text-left w-1/3">Criteria</th>
+            <th className="border px-4 py-2 text-left w-1/3">
+              Conformance Level
+            </th>
+            <th className="border px-4 py-2 text-left w-1/3">
+              Remarks and Explanations
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              501.1 Scope – Incorporation of WCAG 2.2 AA
+            </td>
+            <td className="border px-4 py-2 w-1/3">
+              See{" "}
+              <a href="#WCAG-2.2" className="underline">
+                WCAG 2.2 section
+              </a>
+            </td>
+            <td className="border px-4 py-2 w-1/3">
+              See information in WCAG 2.2 section
+            </td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              <a
+                className="underline italic font-bold"
+                href="https://www.access-board.gov/ict/#502-interoperability-assistive-technology"
+              >
+                {" "}
+                502 Interoperability with Assistive Technology
+              </a>
+            </td>
+            <td className="border px-4 py-2 w-1/3"></td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              502.2.1 User Control of Accessibility Features
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              We do not have specific accessibility features in the website. We
+              support the accessibility features of user agents (ex. supported
+              browsers & screen readers)
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              502.2.2 No Disruption of Accessibility Features
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              We do not have specific accessibility features in the website. We
+              support the accessibility features of user agents (ex. supported
+              browsers & screen readers)
+            </td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3 underline italic font-bold bg-zinc-200">
+              502.3 Accessibility Services
+            </td>
+            <td className="border px-4 py-2 w-1/3 bg-zinc-200"></td>
+            <td className="border px-4 py-2 w-1/3 bg-zinc-200"></td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              502.3.1 Object Information
+            </td>
+            <td className="border px-4 py-2 w-1/3">Partially supports</td>
+            <td className="border px-4 py-2 w-1/3">
+              Some elements found in the Find Properties page, such as the
+              filters, list box, toggle buttons & pagination does not announce
+              the change of state.
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              502.3.2 Modification of Object Information
+            </td>
+            <td className="border px-4 py-2 w-1/3">Partially supports</td>
+            <td className="border px-4 py-2 w-1/3">
+              Some elements found in the Find Properties page, such as the
+              filters, list box, toggle buttons, pagination & zero search
+              results have known issues.
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              502.3.3 Row, Column, and Headers
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">502.3.4 Values</td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              502.3.5 Modification of Values
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              502.3.6 Label Relationships
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              502.3.7 Hierarchical Relationships
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">502.3.8 Text</td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              502.3.9 Modification of Text
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">502.3.10 List of Actions</td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              502.3.11 Actions on Objects
+            </td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">502.3.12 Focus Cursor</td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              502.3.13 Modification of Focus Cursor
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              We don’t have custom focus indicator; we make use of the user
+              agent’s focus indicator.
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              502.3.14 Event Notification
+            </td>
+            <td className="border px-4 py-2 w-1/3">Partially supports</td>
+            <td className="border px-4 py-2 w-1/3">
+              We currently don’t announce the change of state on some behaviors
+              found on the Find Properties page, such as the pagination and when
+              properties yield no results.
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              502.4 Platform Accessibility Features
+            </td>
+            <td className="border px-4 py-2 w-1/3"></td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3 bg-zinc-200">
+              <a
+                className="underline italic font-bold"
+                href="https://www.access-board.gov/ict/#503-applications"
+              >
+                503 Applications
+              </a>
+            </td>
+            <td className="border px-4 py-2 w-1/3 bg-zinc-200"></td>
+            <td className="border px-4 py-2 w-1/3 bg-zinc-200"></td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">503.2 User Preferences</td>
+            <td className="border px-4 py-2 w-1/3">Supports</td>
+            <td className="border px-4 py-2 w-1/3"></td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              503.3 Alternative User Interfaces
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              We do not have alternative user interface.
+            </td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3 bg-zinc-200 italic font-bold">
+              503.4 User Controls for Captions and Audio Description
+            </td>
+            <td className="border px-4 py-2 w-1/3 bg-zinc-200"></td>
+            <td className="border px-4 py-2 w-1/3 bg-zinc-200"></td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">503.4.1 Caption Controls</td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              There are currently no audio or video media in the website
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              503.4.2 Audio Description Controls
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              There are currently no audio or video media in the website
+            </td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3 bg-zinc-200">
+              <a
+                className="underline italic font-bold"
+                href="https://www.access-board.gov/ict/#504-authoring-tools"
+              >
+                504 Authoring Tools
+              </a>
+            </td>
+            <td className="border px-4 py-2 w-1/3 bg-zinc-200"></td>
+            <td className="border px-4 py-2 w-1/3 bg-zinc-200"></td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              504.2 Content Creation or Editing
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              The website is not a content creation or an editing tool
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              504.2.1 Preservation of Information Provided for Accessibility in
+              Format Conversion
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              The website is not a content creation or an editing tool
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">504.2.2 PDF Export</td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              The website doesn’t offer PDF exports
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">504.3 Prompts</td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              The website is not a content creation or an editing tool
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">504.4 Templates</td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              The website is not a content creation or an editing tool
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3 className="text-xl font-semibold my-2">
+        Chapter 6:{" "}
+        <a
+          className="underline"
+          href="https://www.access-board.gov/ict/#chapter-6-support-documentation-and-services"
+        >
+          Support Documentation and Services
+        </a>
+      </h3>
+      <p className="mb-1">Notes:</p>
+      <table className="min-w-full bg-white border-collapse my-4">
+        <thead>
+          <tr>
+            <th className="border px-4 py-2 text-left w-1/3">Criteria</th>
+            <th className="border px-4 py-2 text-left w-1/3">
+              Conformance Level
+            </th>
+            <th className="border px-4 py-2 text-left w-1/3">
+              Remarks and Explanations
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td className="border px-4 py-2 w-1/3 bg-zinc-200 italic font-bold">
+              601.1 Scope
+            </td>
+            <td className="border px-4 py-2 w-1/3 bg-zinc-200"></td>
+            <td className="border px-4 py-2 w-1/3 bg-zinc-200"></td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3 bg-zinc-200">
+              <a
+                className="underline italic font-bold"
+                href="https://www.access-board.gov/ict/#602-support-documentation"
+              >
+                602 Support Documentation
+              </a>
+            </td>
+            <td className="border px-4 py-2 w-1/3 bg-zinc-200"></td>
+            <td className="border px-4 py-2 w-1/3 bg-zinc-200"></td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              602.2 Accessibility and Compatibility Features
+            </td>
+            <td className="border px-4 py-2 w-1/3">Does not support</td>
+            <td className="border px-4 py-2 w-1/3">
+              We do not have documentation that outlines the built-in
+              accessibility and compatibility with assistive technology.
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              602.3 Electronic Support Documentation
+            </td>
+            <td className="border px-4 py-2 w-1/3">
+              See{" "}
+              <a className="underline" href="#WCAG-2.2">
+                WCAG 2.2 section
+              </a>
+            </td>
+            <td className="border px-4 py-2 w-1/3">
+              See information in WCAG 2.2 section
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              602.4 Alternate Formats for Non- Electronic Support Documentation
+            </td>
+            <td className="border px-4 py-2 w-1/3">Not applicable</td>
+            <td className="border px-4 py-2 w-1/3">
+              The website doesn’t have nonelectronic support documentation
+            </td>
+          </tr>
+
+          <tr>
+            <td className="border px-4 py-2 w-1/3 bg-zinc-200">
+              <a
+                className="underline italic font-bold"
+                href="https://www.access-board.gov/ict/#603-support-services"
+              >
+                603 Support Services
+              </a>
+            </td>
+            <td className="border px-4 py-2 w-1/3 bg-zinc-200"></td>
+            <td className="border px-4 py-2 w-1/3 bg-zinc-200"></td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              603.2 Information on Accessibility and Compatibility Features
+            </td>
+            <td className="border px-4 py-2 w-1/3">Does not support</td>
+            <td className="border px-4 py-2 w-1/3">
+              We currently don’t have accessibility information in the website
+            </td>
+          </tr>
+          <tr>
+            <td className="border px-4 py-2 w-1/3">
+              603.3 Accommodation of Communication Needs
+            </td>
+            <td className="border px-4 py-2 w-1/3">Does not support</td>
+            <td className="border px-4 py-2 w-1/3">
+              We currently don’t have support contact for accessibility feedback
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </>
+  );
+}

--- a/src/app/(content-pages)/vpat/VPATPage.tsx
+++ b/src/app/(content-pages)/vpat/VPATPage.tsx
@@ -65,7 +65,7 @@ export default function VPATPage() {
 
       <table
         className="min-w-full bg-white border-collapse my-4"
-        aria-describedby="standards-guidelines"
+        aria-labelledby="standards-guidelines"
       >
         <thead>
           <tr>
@@ -235,7 +235,7 @@ export default function VPATPage() {
       </p>
       <table
         className="min-w-full bg-white border-collapse my-4"
-        aria-describedby="wcag-level-a"
+        aria-labelledby="wcag-level-a"
       >
         <thead>
           <tr>
@@ -1039,7 +1039,7 @@ export default function VPATPage() {
       </p>
       <table
         className="min-w-full bg-white border-collapse my-4"
-        aria-describedby="wcag-level-aa"
+        aria-labelledby="wcag-level-aa"
       >
         <thead>
           <tr>
@@ -1649,7 +1649,7 @@ export default function VPATPage() {
       </p>
       <table
         className="min-w-full bg-white border-collapse my-4"
-        aria-describedby="functional-performance-criteria"
+        aria-labelledby="functional-performance-criteria"
       >
         <thead>
           <tr>
@@ -1771,7 +1771,7 @@ export default function VPATPage() {
       <p className="mb-1">Notes:</p>
       <table
         className="min-w-full bg-white border-collapse my-4"
-        aria-describedby="software"
+        aria-labelledby="software"
       >
         <thead>
           <tr>
@@ -2087,7 +2087,7 @@ export default function VPATPage() {
       <p className="mb-1">Notes:</p>
       <table
         className="min-w-full bg-white border-collapse my-4"
-        aria-describedby="support-doc-services"
+        aria-labelledby="support-doc-services"
       >
         <thead>
           <tr>

--- a/src/app/(content-pages)/vpat/VPATPage.tsx
+++ b/src/app/(content-pages)/vpat/VPATPage.tsx
@@ -64,10 +64,10 @@ export default function VPATPage() {
       <table className="min-w-full bg-white border-collapse my-4">
         <thead>
           <tr>
-            <th className="border px-4 py-2 text-left w-1/2 bg-zinc-200">
+            <th className="border px-4 py-2 text-left w-1/2 bg-zinc-200 text-zinc-500">
               Standard/Guideline
             </th>
-            <th className="border px-4 py-2 text-left w-1/2 bg-zinc-200">
+            <th className="border px-4 py-2 text-left w-1/2 bg-zinc-200 text-zinc-500">
               Included In Report
             </th>
           </tr>
@@ -231,13 +231,13 @@ export default function VPATPage() {
       <table className="min-w-full bg-white border-collapse my-4">
         <thead>
           <tr>
-            <th className="sticky top-0 border px-4 py-2 text-left w-1/3">
+            <th className="border px-4 py-2 text-left w-1/3 bg-zinc-200 text-zinc-500">
               Criteria
             </th>
-            <th className="sticky top-0 border px-4 py-2 text-left w-1/3">
+            <th className="border px-4 py-2 text-left w-1/3 bg-zinc-200 text-zinc-500">
               Conformance Level
             </th>
-            <th className="sticky top-0 border px-4 py-2 text-left w-1/3">
+            <th className="border px-4 py-2 text-left w-1/3 bg-zinc-200 text-zinc-500">
               Remarks and Explanations
             </th>
           </tr>

--- a/src/app/(content-pages)/vpat/VPATPage.tsx
+++ b/src/app/(content-pages)/vpat/VPATPage.tsx
@@ -1,14 +1,14 @@
 export default function VPATPage() {
   return (
     <>
-      <h1 className="text-3xl font-bold mb-6">
+      <h1 className="heading-3xl font-bold mb-6">
         Clean & Green Philly Accessibility Conformance Report
       </h1>
       <p className="mb-1 font-bold">
         Based on VPAT® Version 2.5 International Edition
       </p>
 
-      <h2 className="text-2xl font-semibold my-4">Product Information</h2>
+      <h2 className="heading-2xl font-semibold my-4">Product Information</h2>
       <p className="mb-1">
         <strong>Name of Product/Version:</strong> Clean & Green Philly
       </p>
@@ -193,7 +193,7 @@ export default function VPATPage() {
         </ul>
       </p>
 
-      <h2 className="text-2xl font-semibold my-4" id="WCAG-2.2">
+      <h2 className="heading-2xl font-semibold my-4" id="WCAG-2.2">
         WCAG 2.2 Report
       </h2>
       <p className="mb-1">
@@ -220,7 +220,7 @@ export default function VPATPage() {
         .
       </p>
 
-      <h3 className="text-xl font-semibold my-2">
+      <h3 className="heading-xl font-semibold my-2">
         Table 1: Success Criteria, Level A
       </h3>
       <p className="mb-1">
@@ -1021,7 +1021,7 @@ export default function VPATPage() {
         </tbody>
       </table>
 
-      <h3 className="text-xl font-semibold my-2">
+      <h3 className="heading-xl font-semibold my-2">
         Table 2: Success Criteria, Level AA
       </h3>
       <p className="mb-1">
@@ -1607,7 +1607,7 @@ export default function VPATPage() {
         </tr>
       </table>
 
-      <h2 className="text-2xl font-semibold my-4 bg-zinc-200">
+      <h2 className="heading-2xl font-semibold my-4 bg-zinc-200">
         Revised Section 508 Report
       </h2>
       <p className="mb-1">
@@ -1616,7 +1616,7 @@ export default function VPATPage() {
         we release fixes.
       </p>
 
-      <h3 className="text-xl font-semibold my-2">
+      <h3 className="heading-xl font-semibold my-2">
         Chapter 3:{" "}
         <a
           href="https://www.access-board.gov/ict/#chapter-3-functional-performance-criteria"
@@ -1724,7 +1724,7 @@ export default function VPATPage() {
         </tbody>
       </table>
 
-      <h3 className="text-xl font-semibold my-2">
+      <h3 className="heading-xl font-semibold my-2">
         Section 508 Chapter 4:{" "}
         <a
           href="https://www.access-board.gov/ict/#chapter-4-hardware"
@@ -1739,7 +1739,7 @@ export default function VPATPage() {
         Notes: Not applicable to Clean & Green Philly website.
       </p>
 
-      <h3 className="text-xl font-semibold my-2">
+      <h3 className="heading-xl font-semibold my-2">
         {" "}
         Chapter 5:{" "}
         <a
@@ -1771,8 +1771,13 @@ export default function VPATPage() {
             </td>
             <td className="border px-4 py-2 w-1/3">
               See{" "}
-              <a href="#WCAG-2.2" className="underline">
-                WCAG 2.2 section target="_blank" rel="noopener noreferrer"
+              <a
+                href="#WCAG-2.2"
+                className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                WCAG 2.2 section
               </a>
             </td>
             <td className="border px-4 py-2 w-1/3">
@@ -2048,7 +2053,7 @@ export default function VPATPage() {
         </tbody>
       </table>
 
-      <h3 className="text-xl font-semibold my-2">
+      <h3 className="heading-xl font-semibold my-2">
         Chapter 6:{" "}
         <a
           className="underline"

--- a/src/app/(content-pages)/vpat/VPATPage.tsx
+++ b/src/app/(content-pages)/vpat/VPATPage.tsx
@@ -54,14 +54,19 @@ export default function VPATPage() {
           </li>
         </ul>
       </p>
-      <p className="mb-1 font-bold">Applicable Standards/Guidelines:</p>
+      <p className="mb-1 font-bold" id="standards-guidelines">
+        Applicable Standards/Guidelines:
+      </p>
       <p>
         {" "}
         This report covers the degree of conformance for the following
         accessibility standard/guidelines:
       </p>
 
-      <table className="min-w-full bg-white border-collapse my-4">
+      <table
+        className="min-w-full bg-white border-collapse my-4"
+        aria-describedby="standards-guidelines"
+      >
         <thead>
           <tr>
             <th className="border px-4 py-2 text-left w-1/2 bg-zinc-200 text-zinc-500">
@@ -220,7 +225,7 @@ export default function VPATPage() {
         .
       </p>
 
-      <h3 className="heading-xl font-semibold my-2">
+      <h3 className="heading-xl font-semibold my-2" id="wcag-level-a">
         Table 1: Success Criteria, Level A
       </h3>
       <p className="mb-1">
@@ -228,7 +233,10 @@ export default function VPATPage() {
         site has not been evaluated. We will periodically update this report as
         we release fixes.
       </p>
-      <table className="min-w-full bg-white border-collapse my-4">
+      <table
+        className="min-w-full bg-white border-collapse my-4"
+        aria-describedby="wcag-level-a"
+      >
         <thead>
           <tr>
             <th className="border px-4 py-2 text-left w-1/3 bg-zinc-200 text-zinc-500">
@@ -1021,7 +1029,7 @@ export default function VPATPage() {
         </tbody>
       </table>
 
-      <h3 className="heading-xl font-semibold my-2">
+      <h3 className="heading-xl font-semibold my-2" id="wcag-level-aa">
         Table 2: Success Criteria, Level AA
       </h3>
       <p className="mb-1">
@@ -1029,7 +1037,10 @@ export default function VPATPage() {
         site has not been evaluated. We will periodically update this report as
         we release fixes.
       </p>
-      <table className="min-w-full bg-white border-collapse my-4">
+      <table
+        className="min-w-full bg-white border-collapse my-4"
+        aria-describedby="wcag-level-aa"
+      >
         <thead>
           <tr>
             <th className="border px-4 py-2 text-left w-1/3">Criteria</th>
@@ -1616,7 +1627,10 @@ export default function VPATPage() {
         we release fixes.
       </p>
 
-      <h3 className="heading-xl font-semibold my-2">
+      <h3
+        className="heading-xl font-semibold my-2"
+        id="functional-performance-criteria"
+      >
         Chapter 3:{" "}
         <a
           href="https://www.access-board.gov/ict/#chapter-3-functional-performance-criteria"
@@ -1633,7 +1647,10 @@ export default function VPATPage() {
         Notes: The interactive map needs better accessibility support and
         optimization. We are actively looking to improve this.
       </p>
-      <table className="min-w-full bg-white border-collapse my-4">
+      <table
+        className="min-w-full bg-white border-collapse my-4"
+        aria-describedby="functional-performance-criteria"
+      >
         <thead>
           <tr>
             <th className="border px-4 py-2 text-left w-1/3">Criteria</th>
@@ -1739,7 +1756,7 @@ export default function VPATPage() {
         Notes: Not applicable to Clean & Green Philly website.
       </p>
 
-      <h3 className="heading-xl font-semibold my-2">
+      <h3 className="heading-xl font-semibold my-2" id="software">
         {" "}
         Chapter 5:{" "}
         <a
@@ -1752,7 +1769,10 @@ export default function VPATPage() {
         </a>
       </h3>
       <p className="mb-1">Notes:</p>
-      <table className="min-w-full bg-white border-collapse my-4">
+      <table
+        className="min-w-full bg-white border-collapse my-4"
+        aria-describedby="software"
+      >
         <thead>
           <tr>
             <th className="border px-4 py-2 text-left w-1/3">Criteria</th>
@@ -2053,7 +2073,7 @@ export default function VPATPage() {
         </tbody>
       </table>
 
-      <h3 className="heading-xl font-semibold my-2">
+      <h3 className="heading-xl font-semibold my-2" id="support-doc-services">
         Chapter 6:{" "}
         <a
           className="underline"
@@ -2065,7 +2085,10 @@ export default function VPATPage() {
         </a>
       </h3>
       <p className="mb-1">Notes:</p>
-      <table className="min-w-full bg-white border-collapse my-4">
+      <table
+        className="min-w-full bg-white border-collapse my-4"
+        aria-describedby="support-doc-services"
+      >
         <thead>
           <tr>
             <th className="border px-4 py-2 text-left w-1/3">Criteria</th>

--- a/src/app/(content-pages)/vpat/VPATPage.tsx
+++ b/src/app/(content-pages)/vpat/VPATPage.tsx
@@ -2,29 +2,34 @@ export default function VPATPage() {
   return (
     <>
       <h1 className="text-3xl font-bold mb-6">
-        Accessibility Conformance Report
+        Clean & Green Philly Accessibility Conformance Report
       </h1>
+      <p className="mb-1 font-bold">
+        Based on VPAT® Version 2.5 International Edition
+      </p>
+
       <h2 className="text-2xl font-semibold my-4">Product Information</h2>
       <p className="mb-1">
         <strong>Name of Product/Version:</strong> Clean & Green Philly
       </p>
-      <p className="mb-1">
-        <strong>Report Date:</strong> May 31, 2024
-      </p>
-      <p className="mb-1">
-        <strong>
-          Product Description: Free and easy to use online tool empowering
-          community groups in Philadelphia to combat gun violence through the
-          revitalization of vacant properties via cleaning and greening
-          initiatives.
-        </strong>
+      <p className="mb-1 font-bold">Report Date: May 31, 2024</p>
+      <p className="mb-1 font-bold">
+        Product Description: Free and easy to use online tool empowering
+        community groups in Philadelphia to combat gun violence through the
+        revitalization of vacant properties via cleaning and greening
+        initiatives.
       </p>
       <p className="mb-1">
         <strong>Contact Information:</strong>{" "}
         <ul className="list-disc ml-8 my-2">
           <li>
             {" "}
-            <a href="mailto:cleanandgreenphl@gmail.com" className="underline">
+            <a
+              href="mailto:cleanandgreenphl@gmail.com"
+              className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               cleanandgreenphl@gmail.com
             </a>
           </li>
@@ -49,21 +54,20 @@ export default function VPATPage() {
           </li>
         </ul>
       </p>
-      <p className="mb-1">
-        <strong>Applicable Standards/Guidelines</strong>:
-      </p>
+      <p className="mb-1 font-bold">Applicable Standards/Guidelines:</p>
       <p>
         {" "}
         This report covers the degree of conformance for the following
         accessibility standard/guidelines:
       </p>
+
       <table className="min-w-full bg-white border-collapse my-4">
         <thead>
           <tr>
-            <th className="border px-4 py-2 text-left w-1/2">
+            <th className="border px-4 py-2 text-left w-1/2 bg-zinc-200">
               Standard/Guideline
             </th>
-            <th className="border px-4 py-2 text-left w-1/2">
+            <th className="border px-4 py-2 text-left w-1/2 bg-zinc-200">
               Included In Report
             </th>
           </tr>
@@ -74,6 +78,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/2008/REC-WCAG20-20081211/"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 Web Content Accessibility Guidelines 2.0
               </a>
@@ -88,7 +94,12 @@ export default function VPATPage() {
           </tr>
           <tr>
             <td className="border px-4 py-2 w-1/2">
-              <a href="https://www.w3.org/TR/WCAG21/" className="underline">
+              <a
+                href="https://www.w3.org/TR/WCAG21/"
+                className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 Web Content Accessibility Guidelines 2.1
               </a>
             </td>
@@ -102,7 +113,12 @@ export default function VPATPage() {
           </tr>
           <tr>
             <td className="border px-4 py-2 w-1/2">
-              <a href="https://www.w3.org/TR/WCAG22/" className="underline">
+              <a
+                href="https://www.w3.org/TR/WCAG22/"
+                className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 Web Content Accessibility Guidelines 2.2
               </a>
             </td>
@@ -116,7 +132,12 @@ export default function VPATPage() {
           </tr>
           <tr>
             <td className="border px-4 py-2 w-1/2">
-              <a href="https://www.access-board.gov/ict/" className="underline">
+              <a
+                href="https://www.access-board.gov/ict/"
+                className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 Revised Section 508 standards published January 18, 2017 and
                 corrected January 22, 2018
               </a>
@@ -128,6 +149,8 @@ export default function VPATPage() {
               <a
                 href="https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.01.01_60/en_301549v030101p.pdf"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 EN 301 549 Accessibility requirements for ICT products and
                 services - V3.1.1 (2019-11) AND EN 301 549 Accessibility
@@ -169,6 +192,7 @@ export default function VPATPage() {
           </li>
         </ul>
       </p>
+
       <h2 className="text-2xl font-semibold my-4" id="WCAG-2.2">
         WCAG 2.2 Report
       </h2>
@@ -188,11 +212,14 @@ export default function VPATPage() {
         <a
           href="https://www.w3.org/TR/WCAG20/#conformance-reqs"
           className="underline"
+          target="_blank"
+          rel="noopener noreferrer"
         >
           WCAG 2.0 Conformance Requirements
         </a>
         .
       </p>
+
       <h3 className="text-xl font-semibold my-2">
         Table 1: Success Criteria, Level A
       </h3>
@@ -204,11 +231,13 @@ export default function VPATPage() {
       <table className="min-w-full bg-white border-collapse my-4">
         <thead>
           <tr>
-            <th className="border px-4 py-2 text-left w-1/3">Criteria</th>
-            <th className="border px-4 py-2 text-left w-1/3">
+            <th className="sticky top-0 border px-4 py-2 text-left w-1/3">
+              Criteria
+            </th>
+            <th className="sticky top-0 border px-4 py-2 text-left w-1/3">
               Conformance Level
             </th>
-            <th className="border px-4 py-2 text-left w-1/3">
+            <th className="sticky top-0 border px-4 py-2 text-left w-1/3">
               Remarks and Explanations
             </th>
           </tr>
@@ -219,6 +248,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#text-equiv-all"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>1.1.1 Non-text Content</strong>
               </a>{" "}
@@ -241,6 +272,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#media-equiv-av-only-alt"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>1.2.1 Audio-only and Video-only (Prerecorded)</strong>
               </a>{" "}
@@ -263,6 +296,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#media-equiv-captions"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>1.2.2 Captions (Prerecorded)</strong>
               </a>{" "}
@@ -285,6 +320,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>
                   1.2.3 Audio Description or Media Alternative (Prerecorded)
@@ -309,6 +346,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>1.3.1 Info and Relationships</strong>
               </a>{" "}
@@ -332,6 +371,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#content-structure-separation-sequence"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>1.3.2 Meaningful Sequence</strong>
               </a>{" "}
@@ -355,6 +396,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#content-structure-separation-understanding"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>1.3.3 Sensory Characteristics</strong>
               </a>{" "}
@@ -376,6 +419,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-without-color"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>1.4.1 Use of Color</strong>
               </a>{" "}
@@ -402,6 +447,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-dis-audio"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>1.4.2 Audio Control</strong>
               </a>{" "}
@@ -426,6 +473,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#keyboard-operation-keyboard-operable"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>2.1.1 Keyboard</strong>
               </a>{" "}
@@ -453,6 +502,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#keyboard-operation-trapping"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>2.1.2 No Keyboard Trap</strong>
               </a>{" "}
@@ -475,6 +526,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG21/#character-key-shortcuts"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>2.1.4 Character Key Shortcuts</strong>
               </a>{" "}
@@ -492,6 +545,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#time-limits-required-behaviors"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>2.2.1 Timing Adjustable</strong>
               </a>{" "}
@@ -515,6 +570,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#time-limits-pause"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>2.2.2 Pause, Stop, Hide</strong>
               </a>{" "}
@@ -539,6 +596,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#seizure-does-not-violate"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>2.3.1 Three Flashes or Below Threshold</strong>
               </a>{" "}
@@ -564,6 +623,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>2.4.1 Bypass Blocks</strong>
               </a>{" "}
@@ -589,6 +650,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>2.4.2 Page Titled</strong>
               </a>{" "}
@@ -612,6 +675,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-order"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>2.4.3 Focus Order</strong>
               </a>{" "}
@@ -638,29 +703,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs"
                 className="underline"
-              >
-                <strong>2.4.4 Link Purpose (In Context)</strong>
-              </a>{" "}
-              (Level A) <br />
-              Also applies to:
-              <br /> Revised Section 508
-              <ul className="list-disc ml-8">
-                <li>501 (Web)(Software)</li>
-                <li>504.2 (Authoring Tool)</li>
-                <li>
-                  <strong>602.3 (Support Docs)</strong>
-                </li>
-              </ul>
-            </td>
-            <td className="border px-4 py-2 w-1/3">Supports</td>
-            <td className="border px-4 py-2 w-1/3"></td>
-          </tr>
-
-          <tr>
-            <td className="border px-4 py-2 w-1/3">
-              <a
-                href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs"
-                className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>2.4.4 Link Purpose (In Context)</strong>
               </a>{" "}
@@ -684,6 +728,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG21/#pointer-gestures"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>2.5.1 Pointer Gestures</strong>
               </a>{" "}
@@ -700,6 +746,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG21/#pointer-cancellation"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>2.5.2 Pointer Cancellation</strong>
               </a>{" "}
@@ -716,6 +764,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG21/#label-in-name"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>2.5.3 Label in Name</strong>
               </a>{" "}
@@ -732,6 +782,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG21/#motion-actuation"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>2.5.4 Motion Actuation</strong>
               </a>{" "}
@@ -747,6 +799,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#meaning-doc-lang-id"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>3.1.1 Language of Page</strong>
               </a>{" "}
@@ -771,6 +825,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#consistent-behavior-receive-focus"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>3.2.1 On Focus</strong>
               </a>{" "}
@@ -795,6 +851,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#consistent-behavior-unpredictable-change"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>3.2.2 On Input</strong>
               </a>{" "}
@@ -819,6 +877,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG22/#consistent-help"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>3.2.6 Consistent Help</strong>
               </a>{" "}
@@ -834,6 +894,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#minimize-error-identified"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>3.3.1 Error Identification</strong>
               </a>{" "}
@@ -859,6 +921,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#minimize-error-cues"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>3.3.2 Labels or Instructions</strong>
               </a>{" "}
@@ -883,6 +947,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG22/#redundant-entry"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>3.3.7 Redundant Entry</strong>
               </a>{" "}
@@ -899,6 +965,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#ensure-compat-parses"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>4.1.1 Parsing</strong>
               </a>{" "}
@@ -925,6 +993,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#ensure-compat-rsv"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>4.1.2 Name, Role, Value</strong>
               </a>{" "}
@@ -950,6 +1020,7 @@ export default function VPATPage() {
           </tr>
         </tbody>
       </table>
+
       <h3 className="text-xl font-semibold my-2">
         Table 2: Success Criteria, Level AA
       </h3>
@@ -976,6 +1047,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#media-equiv-real-time-captions"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>1.2.4 Captions (Live)</strong>
               </a>{" "}
@@ -999,6 +1072,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc-only"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>1.2.5 Audio Description (Prerecorded)</strong>
               </a>{" "}
@@ -1022,6 +1097,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG21/#orientation"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>1.3.4 Orientation</strong>
               </a>{" "}
@@ -1038,6 +1115,8 @@ export default function VPATPage() {
               <a
                 href="https://www.w3.org/TR/WCAG21/#identify-input-purpose"
                 className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <strong>1.3.5 Identify Input Purpose</strong>
               </a>{" "}
@@ -1055,6 +1134,8 @@ export default function VPATPage() {
             <a
               href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast"
               className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <strong>1.4.3 Contrast (Minimum)</strong>
             </a>{" "}
@@ -1082,6 +1163,8 @@ export default function VPATPage() {
             <a
               href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-scale"
               className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <strong>1.4.4 Resize text</strong>
             </a>{" "}
@@ -1105,6 +1188,8 @@ export default function VPATPage() {
             <a
               href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-presentation"
               className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <strong>1.4.5 Images of Text</strong>
             </a>{" "}
@@ -1130,6 +1215,8 @@ export default function VPATPage() {
             <a
               href="https://www.w3.org/TR/WCAG21/#reflow"
               className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <strong>1.4.10 Reflow</strong>
             </a>{" "}
@@ -1146,6 +1233,8 @@ export default function VPATPage() {
             <a
               href="https://www.w3.org/TR/WCAG21/#non-text-contrast"
               className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <strong>1.4.11 Non-text Contrast</strong>
             </a>{" "}
@@ -1166,6 +1255,8 @@ export default function VPATPage() {
             <a
               href="https://www.w3.org/TR/WCAG21/#text-spacing"
               className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <strong>1.4.12 Text Spacing</strong>
             </a>{" "}
@@ -1183,6 +1274,8 @@ export default function VPATPage() {
             <a
               href="https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus"
               className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <strong>1.4.13 Content on Hover or Focus</strong>
             </a>{" "}
@@ -1198,6 +1291,8 @@ export default function VPATPage() {
             <a
               href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc"
               className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <strong>2.4.5 Multiple Ways</strong>
             </a>{" "}
@@ -1222,6 +1317,8 @@ export default function VPATPage() {
             <a
               href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc"
               className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <strong>2.4.5 Multiple Ways</strong>
             </a>{" "}
@@ -1246,6 +1343,8 @@ export default function VPATPage() {
             <a
               href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive"
               className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <strong>2.4.6 Headings and Labels</strong>
             </a>{" "}
@@ -1269,6 +1368,8 @@ export default function VPATPage() {
             <a
               href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-visible"
               className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <strong>2.4.7 Focus Visible</strong>
             </a>{" "}
@@ -1292,6 +1393,8 @@ export default function VPATPage() {
             <a
               href="https://www.w3.org/TR/WCAG22/#focus-not-obscured-minimum"
               className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <strong>2.4.11 Focus Not Obscured (Minimum)</strong>
             </a>{" "}
@@ -1307,6 +1410,8 @@ export default function VPATPage() {
             <a
               href="https://www.w3.org/TR/WCAG22/#dragging-movements"
               className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <strong>2.5.7 Dragging Movements</strong>
             </a>{" "}
@@ -1324,6 +1429,8 @@ export default function VPATPage() {
             <a
               href="https://www.w3.org/TR/WCAG22/#target-size-minimum"
               className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <strong>2.5.8 Target Size (Minimum)</strong>
             </a>{" "}
@@ -1339,6 +1446,8 @@ export default function VPATPage() {
             <a
               href="https://www.w3.org/TR/WCAG20/#meaning-other-lang-id"
               className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <strong>3.1.2 Language of Parts</strong>
             </a>{" "}
@@ -1362,6 +1471,8 @@ export default function VPATPage() {
             <a
               href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-locations"
               className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <strong>3.2.3 Consistent Navigation</strong>
             </a>{" "}
@@ -1387,6 +1498,8 @@ export default function VPATPage() {
             <a
               href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-functionality"
               className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <strong>3.2.4 Consistent Identification</strong>
             </a>{" "}
@@ -1412,6 +1525,8 @@ export default function VPATPage() {
             <a
               href="https://www.w3.org/TR/WCAG20/#minimize-error-suggestions"
               className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <strong>3.3.3 Error Suggestion</strong>
             </a>{" "}
@@ -1434,6 +1549,8 @@ export default function VPATPage() {
             <a
               href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible"
               className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <strong>3.3.4 Error Prevention (Legal, Financial, Data)</strong>
             </a>{" "}
@@ -1456,6 +1573,8 @@ export default function VPATPage() {
             <a
               href="https://www.w3.org/TR/WCAG22/#accessible-authentication-minimum"
               className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <strong>3.3.8 Accessible Authentication (Minimum)</strong>
             </a>{" "}
@@ -1471,6 +1590,8 @@ export default function VPATPage() {
             <a
               href="https://www.w3.org/TR/WCAG21/#status-messages"
               className="underline"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               <strong>4.1.3 Status Messages</strong>
             </a>{" "}
@@ -1485,6 +1606,7 @@ export default function VPATPage() {
           </td>
         </tr>
       </table>
+
       <h2 className="text-2xl font-semibold my-4 bg-zinc-200">
         Revised Section 508 Report
       </h2>
@@ -1493,11 +1615,14 @@ export default function VPATPage() {
         site has not been evaluated. We will periodically update this report as
         we release fixes.
       </p>
+
       <h3 className="text-xl font-semibold my-2">
         Chapter 3:{" "}
         <a
           href="https://www.access-board.gov/ict/#chapter-3-functional-performance-criteria"
           className="underline"
+          target="_blank"
+          rel="noopener noreferrer"
         >
           {" "}
           Functional Performance Criteria
@@ -1598,11 +1723,14 @@ export default function VPATPage() {
           </tr>
         </tbody>
       </table>
+
       <h3 className="text-xl font-semibold my-2">
         Section 508 Chapter 4:{" "}
         <a
           href="https://www.access-board.gov/ict/#chapter-4-hardware"
           className="underline"
+          target="_blank"
+          rel="noopener noreferrer"
         >
           Hardware
         </a>
@@ -1617,6 +1745,8 @@ export default function VPATPage() {
         <a
           href="https://www.access-board.gov/ict/#chapter-5-software"
           className="underline"
+          target="_blank"
+          rel="noopener noreferrer"
         >
           Software
         </a>
@@ -1642,7 +1772,7 @@ export default function VPATPage() {
             <td className="border px-4 py-2 w-1/3">
               See{" "}
               <a href="#WCAG-2.2" className="underline">
-                WCAG 2.2 section
+                WCAG 2.2 section target="_blank" rel="noopener noreferrer"
               </a>
             </td>
             <td className="border px-4 py-2 w-1/3">
@@ -1655,6 +1785,8 @@ export default function VPATPage() {
               <a
                 className="underline italic font-bold"
                 href="https://www.access-board.gov/ict/#502-interoperability-assistive-technology"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 {" "}
                 502 Interoperability with Assistive Technology
@@ -1687,7 +1819,7 @@ export default function VPATPage() {
           </tr>
 
           <tr>
-            <td className="border px-4 py-2 w-1/3 underline italic font-bold bg-zinc-200">
+            <td className="border px-4 py-2 w-1/3 italic font-bold bg-zinc-200">
               502.3 Accessibility Services
             </td>
             <td className="border px-4 py-2 w-1/3 bg-zinc-200"></td>
@@ -1811,6 +1943,8 @@ export default function VPATPage() {
               <a
                 className="underline italic font-bold"
                 href="https://www.access-board.gov/ict/#503-applications"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 503 Applications
               </a>
@@ -1862,6 +1996,8 @@ export default function VPATPage() {
               <a
                 className="underline italic font-bold"
                 href="https://www.access-board.gov/ict/#504-authoring-tools"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 504 Authoring Tools
               </a>
@@ -1917,6 +2053,8 @@ export default function VPATPage() {
         <a
           className="underline"
           href="https://www.access-board.gov/ict/#chapter-6-support-documentation-and-services"
+          target="_blank"
+          rel="noopener noreferrer"
         >
           Support Documentation and Services
         </a>
@@ -1948,6 +2086,8 @@ export default function VPATPage() {
               <a
                 className="underline italic font-bold"
                 href="https://www.access-board.gov/ict/#602-support-documentation"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 602 Support Documentation
               </a>
@@ -1994,6 +2134,8 @@ export default function VPATPage() {
               <a
                 className="underline italic font-bold"
                 href="https://www.access-board.gov/ict/#603-support-services"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 603 Support Services
               </a>
@@ -2021,6 +2163,7 @@ export default function VPATPage() {
           </tr>
         </tbody>
       </table>
+      <br></br>
     </>
   );
 }

--- a/src/app/(content-pages)/vpat/layout.tsx
+++ b/src/app/(content-pages)/vpat/layout.tsx
@@ -1,0 +1,8 @@
+export const metadata = {
+  title: "Voluntary Product Accessibility Template (VPAT)",
+};
+
+const VPATLayout = ({ children }: { children: React.ReactNode }) => {
+  return <>{children}</>;
+};
+export default VPATLayout;

--- a/src/app/(content-pages)/vpat/page.tsx
+++ b/src/app/(content-pages)/vpat/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { NextUIProvider } from "@nextui-org/react";
+import { FC } from "react";
+import VPATPage from "./VPATPage";
+
+const LegalDisclaimer: FC = () => {
+  return (
+    <NextUIProvider>
+      <VPATPage />
+    </NextUIProvider>
+  );
+};
+
+export default LegalDisclaimer;

--- a/src/app/(content-pages)/vpat/page.tsx
+++ b/src/app/(content-pages)/vpat/page.tsx
@@ -4,7 +4,7 @@ import { NextUIProvider } from "@nextui-org/react";
 import { FC } from "react";
 import VPATPage from "./VPATPage";
 
-const LegalDisclaimer: FC = () => {
+const VPAT: FC = () => {
   return (
     <NextUIProvider>
       <VPATPage />
@@ -12,4 +12,4 @@ const LegalDisclaimer: FC = () => {
   );
 };
 
-export default LegalDisclaimer;
+export default VPAT;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -51,6 +51,17 @@ const Footer = () => {
                 Contact Us
               </a>
             </li>
+
+            <span className="max-sm:hidden">—</span>
+
+            <li className="base-sm underline text-gray-600 mx-auto">
+              <Link
+                href="/accessibility-statement"
+                className="hover:text-gray-800"
+              >
+                Accessibility Statement
+              </Link>
+            </li>
           </ul>
         </nav>
 


### PR DESCRIPTION
- Created two pages: `/accessibility-statement`, `/vapt`.
- Plain html `<table>` tags were used to ensure accessibility. Tested with VoiceOver on Mac - the web content is screen-readable.
- Examplary screenshots (Only partial content on `/vapt` page were captured as the page is long).
<img width="1303" alt="a11y-1" src="https://github.com/CodeForPhilly/clean-and-green-philly/assets/88219993/63929cbf-f226-416e-a3ce-edffd4e40dcd">
<img width="1303" alt="a11y-2" src="https://github.com/CodeForPhilly/clean-and-green-philly/assets/88219993/4f9a46dd-e5cb-47bf-980f-43c2c967806a">
<img width="1303" alt="a11y-3" src="https://github.com/CodeForPhilly/clean-and-green-philly/assets/88219993/d7491d3c-a3c0-4f0e-9929-6d669baac9e2">

![VAT-1-UPDATED](https://github.com/CodeForPhilly/clean-and-green-philly/assets/88219993/3e5f41b9-68fe-4b93-a98a-bb9df96ea22e)

<img width="1303" alt="vpat-2" src="https://github.com/CodeForPhilly/clean-and-green-philly/assets/88219993/8688971d-67b8-4ef2-96b3-40786f530bb3">






Closes #698 