### PR TITLE
Issue 701: cookie banner re-rendering

### DIFF
--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -3,15 +3,25 @@
 import { ThemeButton } from "./ThemeButton";
 import { Check, X } from "@phosphor-icons/react";
 import { useCookieContext } from "@/context/CookieContext";
+import { useEffect, useState } from "react";
 
 const CookieConsentBanner = () => {
   const { shouldShowBanner, setShouldAllowCookies, setShouldShowBanner } =
     useCookieContext();
 
+  const [isClientSide, setIsClientSide] = useState(false);
+
+  useEffect(() => {
+    // Ensure accessing localStorage only runs on the client side.
+    setIsClientSide(true);
+  }, []);
+
   const onClickButton = (shouldSaveCookies: boolean) => {
     setShouldAllowCookies(shouldSaveCookies);
     setShouldShowBanner(false);
   };
+
+  if (!isClientSide) return null;
 
   return (
     <div

--- a/src/context/CookieContext.tsx
+++ b/src/context/CookieContext.tsx
@@ -4,6 +4,7 @@ import React, {
   useContext,
   useState,
   ReactNode,
+  useEffect,
 } from "react";
 
 interface CookieContextProps {
@@ -30,8 +31,22 @@ export const useCookieContext = () => {
 };
 
 export const CookieProvider: FC<CookieProviderProps> = ({ children }) => {
-  const [shouldAllowCookies, setShouldAllowCookies] = useState(false);
-  const [shouldShowBanner, setShouldShowBanner] = useState(true);
+  const [shouldAllowCookies, setShouldAllowCookies] = useState(() => {
+    const storedPrefs = localStorage.getItem("cookiePrefs");
+    return storedPrefs ? JSON.parse(storedPrefs).shouldAllowCookies : false;
+  });
+
+  const [shouldShowBanner, setShouldShowBanner] = useState<boolean>(() => {
+    const storedPrefs = localStorage.getItem("cookiePrefs");
+    return storedPrefs ? JSON.parse(storedPrefs).shouldShowBanner : true;
+  });
+
+  useEffect(() => {
+    localStorage.setItem(
+      "cookiePrefs",
+      JSON.stringify({ shouldAllowCookies, shouldShowBanner })
+    );
+  }, [shouldAllowCookies, shouldShowBanner]);
 
   return (
     <CookieContext.Provider

--- a/src/context/CookieContext.tsx
+++ b/src/context/CookieContext.tsx
@@ -31,14 +31,20 @@ export const useCookieContext = () => {
 };
 
 export const CookieProvider: FC<CookieProviderProps> = ({ children }) => {
-  const [shouldAllowCookies, setShouldAllowCookies] = useState(() => {
-    const storedPrefs = localStorage.getItem("cookiePrefs");
-    return storedPrefs ? JSON.parse(storedPrefs).shouldAllowCookies : false;
+  const [shouldAllowCookies, setShouldAllowCookies] = useState<boolean>(() => {
+    if (typeof window !== "undefined" && window.localStorage) {
+      const storedPrefs = localStorage.getItem("cookiePrefs");
+      return storedPrefs ? JSON.parse(storedPrefs).shouldAllowCookies : false;
+    }
+    return false;
   });
 
   const [shouldShowBanner, setShouldShowBanner] = useState<boolean>(() => {
-    const storedPrefs = localStorage.getItem("cookiePrefs");
-    return storedPrefs ? JSON.parse(storedPrefs).shouldShowBanner : true;
+    if (typeof window !== "undefined" && window.localStorage) {
+      const storedPrefs = localStorage.getItem("cookiePrefs");
+      return storedPrefs ? JSON.parse(storedPrefs).shouldShowBanner : true;
+    }
+    return true;
   });
 
   useEffect(() => {


### PR DESCRIPTION
#701 

This resolves the cookie banner re-rendering by recording/checking the user's local storage.

The issue can be recreated by: 
- running localhost
- take action on cookie banner, either accept or decline
- refresh tab, or open new tab and the cookie banner should re-render

<img width="300" alt="Screenshot 2024-06-22 at 7 02 37 PM" src="https://github.com/CodeForPhilly/clean-and-green-philly/assets/8365273/cd85c783-447e-47ea-a0b3-13043008f299">
<img width="300" alt="Screenshot 2024-06-22 at 7 02 47 PM" src="https://github.com/CodeForPhilly/clean-and-green-philly/assets/8365273/3004a6fb-46be-4f0d-942f-490890b928a9">
