### PR TITLE
Copy tiles file to backup/ instead of move

### DIFF
--- a/data/src/classes/backup_archive_database.py
+++ b/data/src/classes/backup_archive_database.py
@@ -120,7 +120,7 @@ class BackupArchiveDatabase:
             name, ext = os.path.splitext(blob.name)
             backup_file_name: str = tile_file_backup_directory + "/" + name + suffix + ext
             log.debug(backup_file_name)
-            bucket.rename_blob(blob,new_name=backup_file_name)
+            bucket.copy_blob(blob,destination_bucket=bucket,new_name=backup_file_name)
             count += 1
         if count == 0:
             log.warning("No files were found to back up.")

--- a/data/src/classes/diff_report.py
+++ b/data/src/classes/diff_report.py
@@ -48,7 +48,7 @@ class DiffReport:
         """
         self.diff_tables = self._list_diff_tables()
         self.timestamp_string = timestamp_string
-        self.report: str = "The back-end data has been fully refreshed.  Here is the diff report on " + len(self.diff_tables) + " key tables.\nLegend: table A = new data, table B = old data.\n\n"
+        self.report: str = "The back-end data has been fully refreshed.  Here is the diff report on " + str(len(self.diff_tables)) + " key tables.\nLegend: table A = new data, table B = old data.\n\n"
 
     def run(self):
         """


### PR DESCRIPTION
Copy the tiles files to backup instead of rename so we save original files in the base dir if they are used.