### PR TITLE
Issue 700: Add custom 404 page

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,24 @@
+import { ThemeButtonLink } from "@/components/ThemeButton";
+import { Header } from "@/components";
+
+export default function NotFound() {
+  return (
+    <>
+      <div className="flex flex-col min-h-screen">
+        <Header />
+        <main className="flex-grow flex items-center justify-center">
+          <div className="text-center">
+            <h2 className="heading-3xl mb-4">404</h2>
+            <p className="body-md mb-4">This page cannot be found.</p>
+            <ThemeButtonLink
+              href={"/"}
+              className="text-[#03141B] mx-auto inline-block"
+              color="secondary"
+              label="Return to Home"
+            />
+          </div>
+        </main>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
This adds a custom 404 page.
It adds not-found.tsx to src/app/.
The navbar will still be present.
It has a return to home link. 
It should work for any incorrect url.

![clean and green 404](https://github.com/CodeForPhilly/clean-and-green-philly/assets/111008425/af5b0cdd-4969-40f5-a998-46e23f6c5609)


Addresses ticket #700  
