### PR TITLE
Issue 619: Link Color Contrast

### DIFF
--- a/src/app/(content-pages)/transform-property/TransformPropertyPage.tsx
+++ b/src/app/(content-pages)/transform-property/TransformPropertyPage.tsx
@@ -303,7 +303,7 @@ export default function TransformPropertyPage() {
           their parks.
         </p>
         <ThemeButtonLink
-          className="text-[#0070F0] inline-flex"
+          className="text-blue-900 inline-flex"
           href={parkInATruckUrl}
           target="_blank"
           rel="noopener noreferrer"
@@ -326,7 +326,7 @@ export default function TransformPropertyPage() {
           housing in historically neglected neighborhoods.
         </p>
         <ThemeButtonLink
-          className="text-[#0070F0] inline-flex"
+          className="text-blue-900 inline-flex"
           href={jumpStartUrl}
           target="_blank"
           rel="noopener noreferrer"
@@ -347,7 +347,7 @@ export default function TransformPropertyPage() {
           and connect you with other resources.
         </p>
         <ThemeButtonLink
-          className="text-[#0070F0] inline-flex"
+          className="text-blue-900  inline-flex"
           href={localRepresentativesUrl}
           target="_blank"
           rel="noopener noreferrer"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -200,7 +200,7 @@
 }
 
 .link {
-  @apply text-[#0070F0] underline;
+  @apply text-blue-900 underline;
 }
 
 /* Styles for the mapbox legend pane. */

--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -81,7 +81,7 @@ const ContentCard: FC<ContentCardProps> = ({
               links.map((link, index) => (
                 <ThemeButtonLink
                   key={index}
-                  className="text-blue-700 !bg-green-100 !px-0 !py-0 mb-2 h-5 !text-left !items-start"
+                  className="text-blue-900 !bg-green-100 !px-0 !py-0 mb-2 h-5 !text-left !items-start"
                   color="tertiary"
                   aria-label={link.text + " Link opens in new tab"}
                   href={link.url}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -29,6 +29,7 @@ const config: Config = {
         },
         blue: {
           DEFAULT: "#3867DE",
+          900: "#1C00F0",
           800: "#003144",
           400: "#57BEE7",
           300: "#84D5F5",


### PR DESCRIPTION
Tailwind is new to me but this is a small change that will address the color contrast issues appropriately. I checked how these color keys work and i added in a 900 key, that is indeed the darkest of the blues.
It does look like this change will effect ~34 links via: `className="link"`, some of which don't _need_ the change for the scope of this issue. I changed some other link colors just so there aren't 2 different link colors throughout the app.

I have checked most of these spots and they do seem fine. Most of the blues this touches seem to either be blue on white or blue on green which don't break contrast rules.


https://color.a11y.com/ContrastPair/?bgcolor=E5F8FF&fgcolor=1C00F0

Before:
<img width="200" alt="Screenshot 2024-06-25 at 8 26 05 PM" src="https://github.com/CodeForPhilly/clean-and-green-philly/assets/8365273/0951be15-572c-43a3-86c8-73957e2f004e">

After:
<img width="200" alt="Screenshot 2024-06-25 at 8 26 15 PM" src="https://github.com/CodeForPhilly/clean-and-green-philly/assets/8365273/d46c3437-daf0-4d3c-84b0-db97a93438ac">

Closes #619 