### PR TITLE
619: Change tailwind config and add new contrast friendly blue

### DIFF
--- a/src/app/(content-pages)/transform-property/TransformPropertyPage.tsx
+++ b/src/app/(content-pages)/transform-property/TransformPropertyPage.tsx
@@ -303,7 +303,7 @@ export default function TransformPropertyPage() {
           their parks.
         </p>
         <ThemeButtonLink
-          className="text-[#0070F0] inline-flex"
+          className="text-blue-900 inline-flex"
           href={parkInATruckUrl}
           target="_blank"
           rel="noopener noreferrer"
@@ -326,7 +326,7 @@ export default function TransformPropertyPage() {
           housing in historically neglected neighborhoods.
         </p>
         <ThemeButtonLink
-          className="text-[#0070F0] inline-flex"
+          className="text-blue-900 inline-flex"
           href={jumpStartUrl}
           target="_blank"
           rel="noopener noreferrer"
@@ -347,7 +347,7 @@ export default function TransformPropertyPage() {
           and connect you with other resources.
         </p>
         <ThemeButtonLink
-          className="text-[#0070F0] inline-flex"
+          className="text-blue-900  inline-flex"
           href={localRepresentativesUrl}
           target="_blank"
           rel="noopener noreferrer"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -200,7 +200,7 @@
 }
 
 .link {
-  @apply text-[#0070F0] underline;
+  @apply text-blue-900 underline;
 }
 
 /* Styles for the mapbox legend pane. */

--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -81,7 +81,7 @@ const ContentCard: FC<ContentCardProps> = ({
               links.map((link, index) => (
                 <ThemeButtonLink
                   key={index}
-                  className="text-blue-700 !bg-green-100 !px-0 !py-0 mb-2 h-5 !text-left !items-start"
+                  className="text-blue-900 !bg-green-100 !px-0 !py-0 mb-2 h-5 !text-left !items-start"
                   color="tertiary"
                   aria-label={link.text + " Link opens in new tab"}
                   href={link.url}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -29,6 +29,7 @@ const config: Config = {
         },
         blue: {
           DEFAULT: "#3867DE",
+          900: "#1C00F0",
           800: "#003144",
           400: "#57BEE7",
           300: "#84D5F5",


### PR DESCRIPTION
Issue #619

old pr: https://github.com/CodeForPhilly/clean-and-green-philly/pull/713

Make blue links darker to pass contrast color ratio. Adds new dark blue color and swap out all blue links to use new 900 blue.