### PR TITLE
Add aria-current to page buttons

### DIFF
--- a/src/components/PropertyDetailSection.tsx
+++ b/src/components/PropertyDetailSection.tsx
@@ -12,6 +12,7 @@ import {
 import { ThemeButton } from "./ThemeButton";
 import { PiCaretRight, PiCaretLeft } from "react-icons/pi";
 import {
+  Link,
   Table,
   TableHeader,
   TableColumn,
@@ -141,6 +142,7 @@ const PropertyDetailSection: FC<PropertyDetailSectionProps> = ({
             : "bg-white text-gray-900 rounded-md shadow-none rounded-md content-center"
         }`}
         aria-label={isActive ? `Page ${value}` : `Go to page ${value}`}
+        aria-current={isActive ? "page" : false}
         onPress={() => setPage(value)}
         label={value}
       >

--- a/src/components/PropertyDetailSection.tsx
+++ b/src/components/PropertyDetailSection.tsx
@@ -12,7 +12,6 @@ import {
 import { ThemeButton } from "./ThemeButton";
 import { PiCaretRight, PiCaretLeft } from "react-icons/pi";
 import {
-  Link,
   Table,
   TableHeader,
   TableColumn,


### PR DESCRIPTION
This PR closes issue #656 

Adds an 'aria-current' attribute to the pagination page buttons.

To test, use a screen reader and navigate to the pagination buttons at the bottom of the property list view of the 'Find Properties' page.

- On pressing an unselected page button, the screen reader should announce, "Current page, page #".
- If you navigate away from the selected page button and then navigate back to it, the screen reader should announce, "Page # button, current page".