### PR TITLE
Fix #318: Renamed "Properties in View" and added item count 

### DIFF
--- a/src/components/PropertyDetailSection.tsx
+++ b/src/components/PropertyDetailSection.tsx
@@ -250,6 +250,9 @@ const PropertyDetailSection: FC<PropertyDetailSectionProps> = ({
                 disableCursorAnimation={true}
               ></Pagination>
             </div>
+            <p className="text-center mt-4">
+              {`${((page - 1) * 6) + 1}-${page === pages ? featuresInView.length : (page * 6)} of ${featuresInView.length}`}
+            </p>
             <div className="flex w-full justify-center py-4 px-6">
               <p className="body-sm text-gray-500">
                 Note: only the first 100 properties can be viewed in list.

--- a/src/components/PropertyDetailSection.tsx
+++ b/src/components/PropertyDetailSection.tsx
@@ -251,7 +251,7 @@ const PropertyDetailSection: FC<PropertyDetailSectionProps> = ({
               ></Pagination>
             </div>
             <p className="text-center mt-4">
-              {`${((page - 1) * 6) + 1}-${page === pages ? featuresInView.length : (page * 6)} of ${featuresInView.length}`}
+              {`${((page - 1) * 6) + 1} to ${page === pages ? featuresInView.length : (page * 6)} of ${featuresInView.length}`}
             </p>
             <div className="flex w-full justify-center py-4 px-6">
               <p className="body-sm text-gray-500">

--- a/src/components/SidePanelControlBar.tsx
+++ b/src/components/SidePanelControlBar.tsx
@@ -80,7 +80,7 @@ const SearchBarComponent: FC<SidePanelControlBarProps> = ({
                 ? savedPropertyCount
                 : featureCount.toLocaleString()}{" "}
             </span>
-            Properties <span className="max-xl:hidden"> in View </span>
+            <span className="sm:hidden lg:inline"> Total </span> Properties 
           </h1>
         </div>
         {/* Right-aligned content: Buttons */}


### PR DESCRIPTION
## Description
This PR addresses issue #318. Changed "Properties In View" to "Total Properties" and added item count. 
