### PR TITLE
Moved "learn more" link fragment spans to be above subject header

### DIFF
--- a/src/app/(content-pages)/methodology/MethodologyPage.tsx
+++ b/src/app/(content-pages)/methodology/MethodologyPage.tsx
@@ -25,8 +25,6 @@ export default function MethodologyPage() {
           residents, CDCs, City government offices, academic researchers, and
           more.
         </p>
-        {/* Offset for clicking on learn more from filter, scrolls to section below */}
-        <span id="priority-method"></span>
         <p className="body-md">
           Although we aim to simplify the decision-making process for users of
           Clean & Green Philly, we value transparency. Below, we lay out key
@@ -39,6 +37,7 @@ export default function MethodologyPage() {
           .
         </p>
 
+        <span id="priority-method"></span>
         <div className="container mx-auto md:my-12">
           <h2 className="heading-2xl font-semibold mb-4">
             How did we determine &ldquo;priority&rdquo;?
@@ -104,8 +103,6 @@ export default function MethodologyPage() {
             </li>
           </ol>
           <br />
-          {/* Offset for clicking on learn more from filter, scrolls to section below */}
-          <span id="access-method"></span>
           <p className="body-md mb-4">
             These specific datasets were chosen based on the original research
             and extensive stakeholder engagement. The decision tree below
@@ -113,6 +110,7 @@ export default function MethodologyPage() {
           </p>
         </div>
 
+        <span id="access-method"></span>
         <div className="container mx-auto md:my-12">
           <h2 className="heading-2xl font-semibold mb-4">
             How did we determine &ldquo;access process&rdquo;?

--- a/src/app/(content-pages)/methodology/MethodologyPage.tsx
+++ b/src/app/(content-pages)/methodology/MethodologyPage.tsx
@@ -37,9 +37,8 @@ export default function MethodologyPage() {
           .
         </p>
 
-        <span id="priority-method"></span>
         <div className="container mx-auto md:my-12">
-          <h2 className="heading-2xl font-semibold mb-4">
+          <h2 id="priority-method" className="heading-2xl font-semibold mb-4">
             How did we determine &ldquo;priority&rdquo;?
           </h2>
 
@@ -110,9 +109,8 @@ export default function MethodologyPage() {
           </p>
         </div>
 
-        <span id="access-method"></span>
         <div className="container mx-auto md:my-12">
-          <h2 className="heading-2xl font-semibold mb-4">
+          <h2 id="access-method" className="heading-2xl font-semibold mb-4">
             How did we determine &ldquo;access process&rdquo;?
           </h2>
 


### PR DESCRIPTION
This PR closes issue #650 

I moved the `<span>`s that serve as targets of the two "learn more" links so that they are immediately above the headers of the sections they are related to.  Visually, the linked-to headers are brought to the top of the Methodology page, and screen readers now announce the header, rather than the previous paragraph.

Question for @bacitracin :  I'm still using the `<span>`s so that the screen reader reads the text of the header and then stops.  I could delete the `<span>`s and instead add `id=...` to the `<div>` containing the header and paragraph text, which was suggested as a possible alternative solution to this issue.  I tested it and the navigation works the same either way.  However, if I add the `id` to the `<div>`, the screen reader reads the header and also reads the first paragraph.  What is the preferred behavior?

Also, for reference, here are some before-and-after screenshots of the "access method" section of the Methodology page as it appears after clicking the "learn more" link:
Before this PR on a large screen:
![Access link large screen original](https://github.com/CodeForPhilly/clean-and-green-philly/assets/140654473/62624746-f866-47c3-aa2a-edaa1833583c)
After this PR on a large screen:
![Access link large screen revised](https://github.com/CodeForPhilly/clean-and-green-philly/assets/140654473/2126951f-b49d-47e5-a86a-a6db3dda42fd)

Before this PR on a small screen:
![Access link small screen original](https://github.com/CodeForPhilly/clean-and-green-philly/assets/140654473/15c8fca5-5fb1-4ef3-bafd-bcfb37acb1ed)
After this PR on a small screen:
![Access link small screen revised](https://github.com/CodeForPhilly/clean-and-green-philly/assets/140654473/509ad4ff-84e9-41ee-82e1-390bdffe981c)
