### PR TITLE
Michael dratch/712 error message if map fails to load

### DIFF
--- a/src/app/find-properties/[[...opa_id]]/page.tsx
+++ b/src/app/find-properties/[[...opa_id]]/page.tsx
@@ -33,7 +33,7 @@ const MapPage = ({ params }: MapPageProps) => {
   const [featureCount, setFeatureCount] = useState<number>(0);
   const [currentView, setCurrentView] = useState<BarClickOptions>("detail");
   const [loading, setLoading] = useState(true);
-  const [loadingError, setLoadingError] = useState(false);
+  const [hasLoadingError, setHasLoadingError] = useState(false);
   const [selectedProperty, setSelectedProperty] =
     useState<MapGeoJSONFeature | null>(null);
   const [isStreetViewModalOpen, setIsStreetViewModalOpen] =
@@ -233,7 +233,7 @@ const MapPage = ({ params }: MapPageProps) => {
                 featuresInView={featuresInView}
                 setFeaturesInView={setFeaturesInView}
                 setLoading={setLoading}
-                setLoadingError={setLoadingError}
+                setHasLoadingError={setHasLoadingError}
                 selectedProperty={selectedProperty}
                 setSelectedProperty={setSelectedProperty}
                 setFeatureCount={setFeatureCount}
@@ -292,7 +292,7 @@ const MapPage = ({ params }: MapPageProps) => {
                 featuresInView={featuresInView}
                 display={currentView as "detail" | "list"}
                 loading={loading}
-                loadingError={loadingError}
+                hasLoadingError={hasLoadingError}
                 selectedProperty={selectedProperty}
                 setSelectedProperty={setSelectedProperty}
                 setIsStreetViewModalOpen={setIsStreetViewModalOpen}

--- a/src/app/find-properties/[[...opa_id]]/page.tsx
+++ b/src/app/find-properties/[[...opa_id]]/page.tsx
@@ -33,6 +33,7 @@ const MapPage = ({ params }: MapPageProps) => {
   const [featureCount, setFeatureCount] = useState<number>(0);
   const [currentView, setCurrentView] = useState<BarClickOptions>("detail");
   const [loading, setLoading] = useState(true);
+  const [loadingError, setLoadingError] = useState(false);
   const [selectedProperty, setSelectedProperty] =
     useState<MapGeoJSONFeature | null>(null);
   const [isStreetViewModalOpen, setIsStreetViewModalOpen] =
@@ -208,118 +209,116 @@ const MapPage = ({ params }: MapPageProps) => {
   }, [currentView, selectedProperty, shouldFilterSavedProperties]);
 
   return (
-      <NextUIProvider>
-        <div className="flex flex-col">
-          <div className="flex flex-grow overflow-hidden">
-            <StreetViewModal
-              isOpen={isStreetViewModalOpen}
-              onClose={() => setIsStreetViewModalOpen(false)}
-            >
-              <StreetView
-                lat={streetViewLocation?.[1].toString() || ""}
-                lng={streetViewLocation?.[0].toString() || ""}
-                yaw="180"
-                pitch="5"
-                fov="0.7"
+    <NextUIProvider>
+      <div className="flex flex-col">
+        <div className="flex flex-grow overflow-hidden">
+          <StreetViewModal
+            isOpen={isStreetViewModalOpen}
+            onClose={() => setIsStreetViewModalOpen(false)}
+          >
+            <StreetView
+              lat={streetViewLocation?.[1].toString() || ""}
+              lng={streetViewLocation?.[0].toString() || ""}
+              yaw="180"
+              pitch="5"
+              fov="0.7"
+            />
+          </StreetViewModal>
+          <div className={`flex-grow ${isVisible("map")}`}>
+            <div className={`sticky top-0 z-10 sm:hidden ${isVisible("map")}`}>
+              <SidePanelControlBar {...controlBarProps} />
+            </div>
+            {isLinkedPropertyParsed ? (
+              <PropertyMap
+                featuresInView={featuresInView}
+                setFeaturesInView={setFeaturesInView}
+                setLoading={setLoading}
+                setLoadingError={setLoadingError}
+                selectedProperty={selectedProperty}
+                setSelectedProperty={setSelectedProperty}
+                setFeatureCount={setFeatureCount}
+                initialViewState={initialViewState}
+                prevCoordinate={prevCoordinateRef.current}
+                setPrevCoordinate={() => (prevCoordinateRef.current = null)}
               />
-            </StreetViewModal>
-            <div className={`flex-grow ${isVisible("map")}`}>
-              <div
-                className={`sticky top-0 z-10 sm:hidden ${isVisible("map")}`}
-              >
+            ) : (
+              <div className="flex w-full h-full justify-center">
+                <Spinner />
+              </div>
+            )}
+          </div>
+          <SidePanel
+            isVisible={isVisible("properties")}
+            selectedProperty={selectedProperty}
+          >
+            {!selectedProperty && (
+              <div className="h-14 sticky top-0 z-10">
                 <SidePanelControlBar {...controlBarProps} />
               </div>
-              {isLinkedPropertyParsed ? (
-                <PropertyMap
-                  featuresInView={featuresInView}
-                  setFeaturesInView={setFeaturesInView}
-                  setLoading={setLoading}
-                  selectedProperty={selectedProperty}
-                  setSelectedProperty={setSelectedProperty}
-                  setFeatureCount={setFeatureCount}
-                  initialViewState={initialViewState}
-                  prevCoordinate={prevCoordinateRef.current}
-                  setPrevCoordinate={() => (prevCoordinateRef.current = null)}
+            )}
+            {currentView === "download" ? (
+              <div className="relative">
+                <ThemeButton
+                  color="secondary"
+                  className="right-4 lg:right-[24px] absolute top-8 min-w-[3rem]"
+                  aria-label="Close download panel"
+                  startContent={<PiX />}
+                  onPress={() => updateCurrentView("detail")}
                 />
+                <div className="p-4 mt-8 text-center">
+                  <h2 className="heading-xl font-semibold mb-4">
+                    Access Our Data
+                  </h2>
+                  <p>
+                    If you are interested in accessing the data behind this
+                    dashboard, please reach out to us at
+                    <a
+                      href="mailto:cleanandgreenphl@gmail.com"
+                      className="text-blue-600 hover:text-blue-800 underline"
+                    >
+                      {" "}
+                      cleanandgreenphl@gmail.com
+                    </a>
+                    . Let us know who you are and why you want the data. We are
+                    happy to share the data with anyone with community-oriented
+                    interests.
+                  </p>
+                </div>
+              </div>
+            ) : currentView === "filter" ? (
+              <FilterView updateCurrentView={updateCurrentView} />
+            ) : (
+              <PropertyDetailSection
+                featuresInView={featuresInView}
+                display={currentView as "detail" | "list"}
+                loading={loading}
+                loadingError={loadingError}
+                selectedProperty={selectedProperty}
+                setSelectedProperty={setSelectedProperty}
+                setIsStreetViewModalOpen={setIsStreetViewModalOpen}
+                shouldFilterSavedProperties={shouldFilterSavedProperties}
+                setShouldFilterSavedProperties={setShouldFilterSavedProperties}
+                smallScreenMode={smallScreenMode}
+                updateCurrentView={updateCurrentView}
+              />
+            )}
+          </SidePanel>
+          <ThemeButton
+            aria-label={`Change to ${smallScreenMode}`}
+            label={smallScreenMode === "map" ? "List View" : "Map View"}
+            className="fixed bottom-10 left-1/2 -ml-[3.5rem] rounded-2xl sm:hidden max-md:min-w-[7rem]"
+            onPress={updateSmallScreenMode}
+            startContent={
+              smallScreenMode === "map" ? (
+                <ListBullets />
               ) : (
-                <div className="flex w-full h-full justify-center">
-                  <Spinner />
-                </div>
-              )}
-            </div>
-            <SidePanel
-              isVisible={isVisible("properties")}
-              selectedProperty={selectedProperty}
-            >
-              {!selectedProperty && (
-                <div className="h-14 sticky top-0 z-10">
-                  <SidePanelControlBar {...controlBarProps} />
-                </div>
-              )}
-              {currentView === "download" ? (
-                <div className="relative">
-                  <ThemeButton
-                    color="secondary"
-                    className="right-4 lg:right-[24px] absolute top-8 min-w-[3rem]"
-                    aria-label="Close download panel"
-                    startContent={<PiX />}
-                    onPress={() => updateCurrentView("detail")}
-                  />
-                  <div className="p-4 mt-8 text-center">
-                    <h2 className="heading-xl font-semibold mb-4">
-                      Access Our Data
-                    </h2>
-                    <p>
-                      If you are interested in accessing the data behind this
-                      dashboard, please reach out to us at
-                      <a
-                        href="mailto:cleanandgreenphl@gmail.com"
-                        className="text-blue-600 hover:text-blue-800 underline"
-                      >
-                        {" "}
-                        cleanandgreenphl@gmail.com
-                      </a>
-                      . Let us know who you are and why you want the data. We
-                      are happy to share the data with anyone with
-                      community-oriented interests.
-                    </p>
-                  </div>
-                </div>
-              ) : currentView === "filter" ? (
-                <FilterView updateCurrentView={updateCurrentView} />
-              ) : (
-                <PropertyDetailSection
-                  featuresInView={featuresInView}
-                  display={currentView as "detail" | "list"}
-                  loading={loading}
-                  selectedProperty={selectedProperty}
-                  setSelectedProperty={setSelectedProperty}
-                  setIsStreetViewModalOpen={setIsStreetViewModalOpen}
-                  shouldFilterSavedProperties={shouldFilterSavedProperties}
-                  setShouldFilterSavedProperties={
-                    setShouldFilterSavedProperties
-                  }
-                  smallScreenMode={smallScreenMode}
-                  updateCurrentView={updateCurrentView}
-                />
-              )}
-            </SidePanel>
-            <ThemeButton
-              aria-label={`Change to ${smallScreenMode}`}
-              label={smallScreenMode === "map" ? "List View" : "Map View"}
-              className="fixed bottom-10 left-1/2 -ml-[3.5rem] rounded-2xl sm:hidden max-md:min-w-[7rem]"
-              onPress={updateSmallScreenMode}
-              startContent={
-                smallScreenMode === "map" ? (
-                  <ListBullets />
-                ) : (
-                  <GlobeHemisphereWest />
-                )
-              }
-            />
-          </div>
+                <GlobeHemisphereWest />
+              )
+            }
+          />
         </div>
-      </NextUIProvider>
+      </div>
+    </NextUIProvider>
   );
 };
 

--- a/src/components/PropertyDetailSection.tsx
+++ b/src/components/PropertyDetailSection.tsx
@@ -50,7 +50,7 @@ interface PropertyDetailSectionProps {
   featuresInView: MapGeoJSONFeature[];
   display: "detail" | "list";
   loading: boolean;
-  loadingError: boolean;
+  hasLoadingError: boolean;
   selectedProperty: MapGeoJSONFeature | null;
   setSelectedProperty: (property: MapGeoJSONFeature | null) => void;
   setIsStreetViewModalOpen: Dispatch<SetStateAction<boolean>>;
@@ -64,7 +64,7 @@ const PropertyDetailSection: FC<PropertyDetailSectionProps> = ({
   featuresInView,
   display,
   loading,
-  loadingError,
+  hasLoadingError,
   selectedProperty,
   setSelectedProperty,
   setIsStreetViewModalOpen,
@@ -174,7 +174,7 @@ const PropertyDetailSection: FC<PropertyDetailSectionProps> = ({
     return featuresInView.slice(start, end);
   }, [page, featuresInView, smallScreenMode]);
 
-  return loadingError ? (
+  return hasLoadingError ? (
     <div className="flex flex-col w-full items-center justify-center p-4 mt-24">
       <div>
         <p className="body-md">We are having technical issues.</p>

--- a/src/components/PropertyDetailSection.tsx
+++ b/src/components/PropertyDetailSection.tsx
@@ -50,6 +50,7 @@ interface PropertyDetailSectionProps {
   featuresInView: MapGeoJSONFeature[];
   display: "detail" | "list";
   loading: boolean;
+  loadingError: boolean;
   selectedProperty: MapGeoJSONFeature | null;
   setSelectedProperty: (property: MapGeoJSONFeature | null) => void;
   setIsStreetViewModalOpen: Dispatch<SetStateAction<boolean>>;
@@ -63,6 +64,7 @@ const PropertyDetailSection: FC<PropertyDetailSectionProps> = ({
   featuresInView,
   display,
   loading,
+  loadingError,
   selectedProperty,
   setSelectedProperty,
   setIsStreetViewModalOpen,
@@ -172,7 +174,16 @@ const PropertyDetailSection: FC<PropertyDetailSectionProps> = ({
     return featuresInView.slice(start, end);
   }, [page, featuresInView, smallScreenMode]);
 
-  return loading ? (
+  return loadingError ? (
+    <div className="flex flex-col w-full items-center justify-center p-4 mt-24">
+      <div>
+        <p className="body-md">We are having technical issues.</p>
+      </div>
+      <div>
+        <p className="body-md">Please try again later.</p>
+      </div>
+    </div>
+  ) : loading ? (
     <div className="flex-grow h-full">
       {/* Center vertically in screen */}
       <div className="flex w-full justify-center p-4 mt-24">

--- a/src/components/PropertyMap.tsx
+++ b/src/components/PropertyMap.tsx
@@ -141,7 +141,7 @@ interface PropertyMapProps {
   featuresInView: MapGeoJSONFeature[];
   setFeaturesInView: Dispatch<SetStateAction<any[]>>;
   setLoading: Dispatch<SetStateAction<boolean>>;
-  setLoadingError: Dispatch<SetStateAction<boolean>>;
+  setHasLoadingError: Dispatch<SetStateAction<boolean>>;
   selectedProperty: MapGeoJSONFeature | null;
   setSelectedProperty: (property: MapGeoJSONFeature | null) => void;
   setFeatureCount: Dispatch<SetStateAction<number>>;
@@ -153,7 +153,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
   featuresInView,
   setFeaturesInView,
   setLoading,
-  setLoadingError,
+  setHasLoadingError,
   selectedProperty,
   setSelectedProperty,
   setFeatureCount,
@@ -441,7 +441,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
         maxZoom={MAX_MAP_ZOOM}
         interactiveLayerIds={layers}
         onError={(e) => {
-          setLoadingError(true);
+          setHasLoadingError(true);
         }}
         onLoad={(e) => {
           setMap(e.target);

--- a/src/components/PropertyMap.tsx
+++ b/src/components/PropertyMap.tsx
@@ -13,7 +13,7 @@ import {
   maptilerApiKey,
   mapboxAccessToken,
   useStagingTiles,
-  googleCloudBucketName
+  googleCloudBucketName,
 } from "../config/config";
 import { useFilter } from "@/context/FilterContext";
 import Map, {
@@ -116,25 +116,32 @@ const MapControls = () => {
       <NavigationControl showCompass={false} position="bottom-right" />
       <GeolocateControl position="bottom-right" />
       <ScaleControl />
-      {(smallScreenToggle || window.innerWidth > 640) ?
-        <MapLegendControl position="bottom-left" setSmallScreenToggle={setSmallScreenToggle} layerStyle={layerStylePolygon} />
-        :
+      {smallScreenToggle || window.innerWidth > 640 ? (
+        <MapLegendControl
+          position="bottom-left"
+          setSmallScreenToggle={setSmallScreenToggle}
+          layerStyle={layerStylePolygon}
+        />
+      ) : (
         <div className="custom-legend-info-div maplibregl-ctrl maplibregl-ctrl-group w-[40px] h-[40px]">
           <ThemeButton
             className="custom-legend-info z-10"
-            startContent={<span className="custom-legend-info-icon maplibregl-ctrl-icon"></span>}
-            onPress={() => setSmallScreenToggle(s => !s)}
+            startContent={
+              <span className="custom-legend-info-icon maplibregl-ctrl-icon"></span>
+            }
+            onPress={() => setSmallScreenToggle((s) => !s)}
           />
         </div>
-      }
+      )}
     </>
-  )
+  );
 };
 
 interface PropertyMapProps {
   featuresInView: MapGeoJSONFeature[];
   setFeaturesInView: Dispatch<SetStateAction<any[]>>;
   setLoading: Dispatch<SetStateAction<boolean>>;
+  setLoadingError: Dispatch<SetStateAction<boolean>>;
   selectedProperty: MapGeoJSONFeature | null;
   setSelectedProperty: (property: MapGeoJSONFeature | null) => void;
   setFeatureCount: Dispatch<SetStateAction<number>>;
@@ -146,6 +153,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
   featuresInView,
   setFeaturesInView,
   setLoading,
+  setLoadingError,
   selectedProperty,
   setSelectedProperty,
   setFeatureCount,
@@ -189,7 +197,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
         layers,
       });
 
-      setSearchedProperty({...searchedProperty, address: "" })
+      setSearchedProperty({ ...searchedProperty, address: "" });
       if (features.length > 0) {
         setSelectedProperty(features[0]);
       } else {
@@ -217,7 +225,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
         }
         return acc;
       },
-      0,
+      0
     );
 
     setFeatureCount(clusteredFeatureCount);
@@ -252,7 +260,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
         map.project(searchedProperty.coordinates),
         {
           layers,
-        },
+        }
       );
       if (features.length > 0) {
         setSelectedProperty(features[0]);
@@ -293,7 +301,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
               tabIndex={0}
             />
           </Tooltip>,
-          legendSummary,
+          legendSummary
         );
       }
 
@@ -302,13 +310,15 @@ const PropertyMap: FC<PropertyMapProps> = ({
         const center = map.getCenter();
         geocoderRef.current = new MapboxGeocoder({
           accessToken: mapboxAccessToken,
-          bbox: [-75.288283,39.864114,-74.945063,40.140129],
+          bbox: [-75.288283, 39.864114, -74.945063, 40.140129],
           filter: function (item) {
             return item.context.some((i) => {
-                return (
-                    (i.id.split('.').shift() === 'place' && i.text === 'Philadelphia') ||
-                    (i.id.split('.').shift() === 'district' && i.text === 'Philadelphia County')
-                );
+              return (
+                (i.id.split(".").shift() === "place" &&
+                  i.text === "Philadelphia") ||
+                (i.id.split(".").shift() === "district" &&
+                  i.text === "Philadelphia County")
+              );
             });
           },
           mapboxgl: mapboxgl,
@@ -321,7 +331,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
 
         map.addControl(geocoderRef.current as unknown as IControl, "top-right");
 
-        geocoderRef.current.on("result", e => {
+        geocoderRef.current.on("result", (e) => {
           const address = e.result.place_name.split(",")[0];
           setSelectedProperty(null);
           setSearchedProperty({
@@ -370,7 +380,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
     const updateFilter = () => {
       if (!map) return;
 
-      const isAnyFilterEmpty = Object.values(appFilter).some(filterItem => {
+      const isAnyFilterEmpty = Object.values(appFilter).some((filterItem) => {
         return filterItem.values.length === 0;
       });
 
@@ -385,7 +395,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
         (acc, [property, filterItem]) => {
           if (filterItem.values.length) {
             const thisFilterGroup: any = ["any"];
-            filterItem.values.forEach(item => {
+            filterItem.values.forEach((item) => {
               if (filterItem.useIndexOfFilter) {
                 thisFilterGroup.push([
                   ">=",
@@ -401,7 +411,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
           }
           return acc;
         },
-        [] as any[],
+        [] as any[]
       );
 
       map.setFilter("vacant_properties_tiles_points", ["all", ...mapFilter]);
@@ -424,16 +434,19 @@ const PropertyMap: FC<PropertyMapProps> = ({
         mapLib={maplibregl as any}
         initialViewState={initialViewState}
         mapStyle={`https://api.maptiler.com/maps/dataviz/style.json?key=${maptilerApiKey}`}
-        onMouseEnter={e => changeCursor(e, "pointer")}
-        onMouseLeave={e => changeCursor(e, "default")}
+        onMouseEnter={(e) => changeCursor(e, "pointer")}
+        onMouseLeave={(e) => changeCursor(e, "default")}
         onClick={onMapClick}
         minZoom={MIN_MAP_ZOOM}
         maxZoom={MAX_MAP_ZOOM}
         interactiveLayerIds={layers}
-        onLoad={e => {
+        onError={(e) => {
+          setLoadingError(true);
+        }}
+        onLoad={(e) => {
           setMap(e.target);
         }}
-        onSourceData={e => {
+        onSourceData={(e) => {
           handleSetFeatures(e);
         }}
         onMoveEnd={handleSetFeatures}


### PR DESCRIPTION
This PR is for this task: Show error message if map fails to load #712

https://github.com/CodeForPhilly/clean-and-green-philly/issues/712

To view the error state go to the find properties page, open dev tools, and block the URL from google storage to simulate a failed API call.



![image](https://github.com/CodeForPhilly/clean-and-green-philly/assets/118772606/6722fc7e-d930-4dd6-bdbf-644f98786204)

On page reload, this error message will be displayed on the property details panel.


![image](https://github.com/CodeForPhilly/clean-and-green-philly/assets/118772606/bbfda3a2-ae0a-4014-98af-52a322703aae)

I think the automatic prettier formatting makes it seem like a lot of lines of code have been changed. But most of these lines are minor changes in formatting. If it would be better for the PR I can redo do these changes with out any of the formatting changes and resubmit.