### PR TITLE
623-saved-button-aria

### DIFF
--- a/src/components/SinglePropertyDetail.tsx
+++ b/src/components/SinglePropertyDetail.tsx
@@ -204,6 +204,8 @@ const SinglePropertyDetail = ({
           <ThemeButton
             color="tertiary"
             label={isPropertySavedToLocalStorage ? "Saved" : "Save"}
+            aria-current={undefined}
+            aria-pressed={isPropertySavedToLocalStorage ? "true" : undefined}
             startContent={
               isPropertySavedToLocalStorage ? <Check /> : <BookmarkSimple />
             }


### PR DESCRIPTION
This closes issue: https://github.com/CodeForPhilly/clean-and-green-philly/issues/623

At first I was going to edit the ThemeButton component but I think that might cause a lot of reworking and it seems like there are some changes coming to the navigation buttons so I added a conditional aria-pressed label for now.

<img width="659" alt="Screen Shot 2024-07-09 at 11 35 53 AM" src="https://github.com/CodeForPhilly/clean-and-green-philly/assets/61482332/209a3545-7736-4a1f-a0a7-85e69bd7ab7f">
<img width="787" alt="Screen Shot 2024-07-09 at 11 35 45 AM" src="https://github.com/CodeForPhilly/clean-and-green-philly/assets/61482332/aa58dc83-f7a3-4e88-9893-257868ea0832">
