### PR TITLE
Zheyichn/748 street view icon fix

### DIFF
--- a/src/components/SinglePropertyDetail.tsx
+++ b/src/components/SinglePropertyDetail.tsx
@@ -266,7 +266,7 @@ const SinglePropertyDetail = ({
               aria-label="Open full screen street view map"
               id="outside-iframe-element"
             >
-              <ArrowsOut color="#3D3D3D" size={24} />
+              <ArrowsOut color="ButtonText" size={24} />
             </button>
           </Tooltip>
         </div>


### PR DESCRIPTION
- Used theme color palatte `ButtonText` on street view icon.
- Screenshoots (dark + light mode):
<img width="568" alt="street-view-icon-dark" src="https://github.com/user-attachments/assets/d99aa52c-487b-4a7a-8b40-0906e107762d">

---
<img width="568" alt="street-view-icon-light" src="https://github.com/user-attachments/assets/4145f4dd-2d59-4329-bff1-58658cc3235e">

Closes #748 
