### PR TITLE
update dependabot to open all PRs against staging rather than main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,25 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    target-branch: 'staging'
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: 'deps'
 
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'weekly'
+    target-branch: 'staging'
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: 'deps'
 
   - package-ecosystem: 'pip'
     directory: '/data/src'
     schedule:
       interval: 'weekly'
+    target-branch: 'staging'
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: 'deps'


### PR DESCRIPTION
limit dependabot PRs to 1 per package ecosystem to minimize excessive PRs