### PR TITLE
822: Fix deployment failure bug

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,8 @@
   "rules": {
     "react/react-in-jsx-scope": "off",
     "react/prop-types": "off",
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-unused-vars": "warn",
     "custom-rules/no-text-size-class": "warn",
     "prettier/prettier": "error"
   },

--- a/src/app/find-properties/[[...opa_id]]/page.tsx
+++ b/src/app/find-properties/[[...opa_id]]/page.tsx
@@ -8,7 +8,6 @@ import {
   SidePanel,
   SidePanelControlBar,
 } from '@/components';
-import { FilterProvider } from '@/context/FilterContext';
 import { NextUIProvider, Spinner } from '@nextui-org/react';
 import { X, GlobeHemisphereWest, ListBullets } from '@phosphor-icons/react';
 import { MapGeoJSONFeature } from 'maplibre-gl';

--- a/src/components/ContentCard.tsx
+++ b/src/components/ContentCard.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react';
+import { FC } from 'react';
 import Image, { StaticImageData } from 'next/image';
 import { ThemeButtonLink } from './ThemeButton';
 import { ArrowUpRight, CaretRight } from '@phosphor-icons/react';
@@ -29,16 +29,10 @@ type ContentCardProps = {
 };
 
 const ContentCard: FC<ContentCardProps> = ({
-  // image,
   image,
   alt,
   title,
   body,
-  description,
-  linkurl,
-  linktext,
-  labelUpkeep,
-  upkeepLevel,
   links,
   details,
   hasArrow,

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,5 @@
 import { Navbar, NavbarBrand, NavbarContent } from '@nextui-org/react';
 import { PiBinoculars, PiKey, PiTree, PiInfo } from 'react-icons/pi';
-import { ThemeButton, ThemeButtonLink } from './ThemeButton';
 import Image from 'next/image';
 import Link from 'next/link';
 import IconLink from './IconLink';

--- a/src/components/Hotjar.tsx
+++ b/src/components/Hotjar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 const Hotjar = () => {
   useEffect(() => {

--- a/src/components/MapLegendControl/MapLegendControl.tsx
+++ b/src/components/MapLegendControl/MapLegendControl.tsx
@@ -1,5 +1,5 @@
 import { ControlPosition, FillLayerSpecification } from 'maplibre-gl';
-import React, { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 import { useControl } from 'react-map-gl';
 import { MapLegendControlClass } from './MapLegend';
 

--- a/src/components/PropertyCard.tsx
+++ b/src/components/PropertyCard.tsx
@@ -21,7 +21,7 @@ function getPriorityClass(priorityLevel: string) {
 }
 
 const PropertyCard = ({ feature, setSelectedProperty }: PropertyCardProps) => {
-  const { address, guncrime_density, tree_canopy_gap, priority_level, opa_id } =
+  const { address, guncrime_density, priority_level, opa_id } =
     feature.properties;
 
   const image = `https://storage.googleapis.com/cleanandgreenphl/${opa_id}.jpg`;

--- a/src/components/PropertyDetailSection.tsx
+++ b/src/components/PropertyDetailSection.tsx
@@ -1,14 +1,6 @@
 'use client';
 
-import {
-  FC,
-  useState,
-  useMemo,
-  useRef,
-  useEffect,
-  SetStateAction,
-  Dispatch,
-} from 'react';
+import { FC, useState, useMemo, useRef, SetStateAction, Dispatch } from 'react';
 import { ThemeButton } from './ThemeButton';
 import { PiCaretRight, PiCaretLeft } from 'react-icons/pi';
 import {
@@ -85,7 +77,6 @@ const PropertyDetailSection: FC<PropertyDetailSectionProps> = ({
       key,
       value,
       isActive,
-      isFirst,
       onNext,
       onPrevious,
       setPage,


### PR DESCRIPTION
## Description

This PR addresses issue #822 where merged PRs are failing to deploy to Vercel's preview and production environments. It appears that `npm run build` is failing due to new plugins recently added to .eslintrc.json. These plugins appear to enforce strict TypeScript-ESLint rules.

This PR reduces the severity of two common TS rules. ESLint now issues a warning instead of throwing errors for them:

- @typescript-eslint/no-explicit-any
- @typescript-eslint/no-unused-vars

This PR also removes some unused variables.

## How this was tested

Before reducing the rules' severity, running `npm run lint` in local env produced these errors:

![Screen Shot 2024-07-22 at 1 58 43 AM](https://github.com/user-attachments/assets/305930bc-609a-43af-b913-dfb8656d1ccd)


After reducing their severity, running `npm run lint` produced warnings instead of errors:

![Screen Shot 2024-07-22 at 1 58 18 AM](https://github.com/user-attachments/assets/4d561c9a-7fe5-4584-ba7c-9165ab8ccda9)