### PR TITLE
822: Fix deployment failure bug — revert mapbox-gl to v3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "clsx": "^2.1.1",
     "framer-motion": "^11.3.8",
     "lodash": "^4.17.21",
-    "mapbox-gl": "^3.5.2",
+    "mapbox-gl": "^3.2.0",
     "maplibre-gl": "^4.5.0",
     "multi-range-slider-react": "^2.0.7",
     "next": "^14.2.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "autoprefixer": "10.4.19",
     "clsx": "^2.1.1",
     "framer-motion": "^11.3.8",
-    "framer-motion": "^11.3.8",
     "lodash": "^4.17.21",
     "mapbox-gl": "^3.5.2",
     "maplibre-gl": "^4.5.0",

--- a/src/components/Filters/MultiSelect.tsx
+++ b/src/components/Filters/MultiSelect.tsx
@@ -11,7 +11,7 @@ import {
 
 type MultiSelectProps = {
   display: string;
-  options: string[];
+  options: any[];
   selectedKeys: string[];
   toggleDimension: (dimension: string) => void;
   handleSelectionChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;


### PR DESCRIPTION
## Description

This PR reverts mapbox-gl from v3.5.2 back to v3.2.0 due to breaking changes. These changes were causing `npm run build` to fail, thus causing the failure of deployment to Vercel's preview and production environments. This PR addresses issue #822.

## Screenshots

Before reverting mapbox-gl to v3.2.0, running `npm run build` in local env failed due to this error:

![Screen Shot 2024-07-22 at 9 22 07 PM](https://github.com/user-attachments/assets/ce7cba3c-4023-4a95-8ff7-b8248813e3d4)

After reverting to v3.2.0, running `npm run build` resulted in a successful build:

<img width="397" alt="Screen Shot 2024-07-22 at 9 46 46 PM" src="https://github.com/user-attachments/assets/4f453c09-0c50-4aaf-b680-9664bf9a6950">

After this PR was submitted, all GitHub checks passed:

![Screen Shot 2024-07-22 at 9 48 16 PM](https://github.com/user-attachments/assets/12bb44ca-9ef4-460b-bccd-684b9b875844)

## Notes

A front-end issue will be created for updating mapbox-gl to v3.5.2. Whoever is assigned the issue will need to resolve breaking changes by refactoring some UI components. I will include details in the issue.