### PR TITLE
767: Fix issue with release version number

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: 'v$NEXT_MAJOR_VERSION.$NEXT_MINOR_VERSION.$NEXT_PATCH_VERSION'
-tag-template: 'v$NEXT_MAJOR_VERSION.$NEXT_MINOR_VERSION.$NEXT_PATCH_VERSION'
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
 categories:
   - title: '🚀 Features'
     labels: [feature]


### PR DESCRIPTION
## Description

This PR addresses #767 by fixing an issue with release version and tag numbers
rendering incorrectly. This PR changes `release-drafter`'s templates for release names and tags
to render them as "v2.0.0" instead of "v2.0.0.1.1.0.1.0.1".

    
   
