### PR TITLE
fix docker formatting and linting

### DIFF
--- a/data/docker-compose.yml
+++ b/data/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       context: .
     volumes:
       - ./src:/usr/src/app
-    command: sh -c "pip install ruff && ruff /usr/src/app --fix --exclude '/usr/src/app/data/src/awkde/' || exit 0"
+    command: sh -c "pip install ruff && ruff /usr/src/app --fix --exclude '/usr/src/app/data/src/awkde/'"
     network_mode: 'host'
 
   linter:
@@ -34,7 +34,7 @@ services:
       context: .
     volumes:
       - ./src:/usr/src/app
-    command: sh -c "pip install ruff && ruff check /usr/src/app --exclude '/usr/src/app/data/src/awkde/' || exit 0"
+    command: sh -c "pip install ruff && ruff check /usr/src/app --exclude '/usr/src/app/data/src/awkde/'"
     network_mode: 'host'
 
   streetview:


### PR DESCRIPTION
prevent builds from completing if they throw formatting or linting errors (previously exited with code 0 regardless)