### PR TITLE
jgrimes86/861 dropdown display bug fix

### DIFF
--- a/src/components/Filters/DimensionFilter.tsx
+++ b/src/components/Filters/DimensionFilter.tsx
@@ -84,12 +84,14 @@ const DimensionFilter: FC<DimensionFilterProps> = ({
     });
   };
 
-  const handleSelectionChange = (selection: React.ChangeEvent<HTMLSelectElement> | string) => {
+  const handleSelectionChange = (
+    selection: React.ChangeEvent<HTMLSelectElement> | string
+  ) => {
     let newMultiSelect: string[] = [];
     if (typeof selection === 'string') {
       newMultiSelect = selectedKeys.includes(selection)
         ? selectedKeys.filter((key) => key !== selection)
-        : [...selectedKeys, selection]
+        : [...selectedKeys, selection];
     } else {
       if (selection.target.value !== '') {
         newMultiSelect = selection.target.value.split(',');

--- a/src/components/Filters/DimensionFilter.tsx
+++ b/src/components/Filters/DimensionFilter.tsx
@@ -84,10 +84,17 @@ const DimensionFilter: FC<DimensionFilterProps> = ({
     });
   };
 
-  const handleSelectionChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newMultiSelect: string[] = e.target.value
-      ? e.target.value.split(',')
-      : [];
+  const handleSelectionChange = (selection: React.ChangeEvent<HTMLSelectElement> | string) => {
+    let newMultiSelect: string[] = [];
+    if (typeof selection === 'string') {
+      newMultiSelect = selectedKeys.includes(selection)
+        ? selectedKeys.filter((key) => key !== selection)
+        : [...selectedKeys, selection]
+    } else {
+      if (selection.target.value !== '') {
+        newMultiSelect = selection.target.value.split(',');
+      }
+    }
     setSelectedKeys(newMultiSelect);
     dispatch({
       type: 'SET_DIMENSIONS',

--- a/src/components/Filters/DimensionFilter.tsx
+++ b/src/components/Filters/DimensionFilter.tsx
@@ -85,7 +85,9 @@ const DimensionFilter: FC<DimensionFilterProps> = ({
   };
 
   const handleSelectionChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newMultiSelect: string[] = e.target.value.split(',');
+    const newMultiSelect: string[] = e.target.value
+      ? e.target.value.split(',')
+      : [];
     setSelectedKeys(newMultiSelect);
     dispatch({
       type: 'SET_DIMENSIONS',

--- a/src/components/Filters/MultiSelect.tsx
+++ b/src/components/Filters/MultiSelect.tsx
@@ -14,7 +14,9 @@ type MultiSelectProps = {
   options: any[];
   selectedKeys: string[];
   toggleDimension: (dimension: string) => void;
-  handleSelectionChange: (selection: React.ChangeEvent<HTMLSelectElement> | string) => void;
+  handleSelectionChange: (
+    selection: React.ChangeEvent<HTMLSelectElement> | string
+  ) => void;
 };
 
 const MultiSelect: FC<MultiSelectProps> = ({

--- a/src/components/Filters/MultiSelect.tsx
+++ b/src/components/Filters/MultiSelect.tsx
@@ -24,12 +24,6 @@ const MultiSelect: FC<MultiSelectProps> = ({
   toggleDimension,
   handleSelectionChange,
 }) => {
-  const multiSelectOptions = options.filter((option) => {
-    if (!selectedKeys.includes(option)) {
-      return option;
-    }
-  });
-
   return (
     <div className="space-x-2 min-h-[33.5px]">
       <SelectFilter
@@ -61,7 +55,7 @@ const MultiSelect: FC<MultiSelectProps> = ({
         }}
         onChange={handleSelectionChange}
       >
-        {multiSelectOptions.map((option) => (
+        {options.map((option) => (
           <SelectFilterItem
             key={option}
             value={option}

--- a/src/components/Filters/MultiSelect.tsx
+++ b/src/components/Filters/MultiSelect.tsx
@@ -14,7 +14,7 @@ type MultiSelectProps = {
   options: any[];
   selectedKeys: string[];
   toggleDimension: (dimension: string) => void;
-  handleSelectionChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  handleSelectionChange: (selection: React.ChangeEvent<HTMLSelectElement> | string) => void;
 };
 
 const MultiSelect: FC<MultiSelectProps> = ({
@@ -45,7 +45,7 @@ const MultiSelect: FC<MultiSelectProps> = ({
                   key={index}
                   classNames={{ base: 'multiSelectChip' }}
                   endContent={<X aria-label={`close ${option}`} />}
-                  onClose={() => toggleDimension(option)}
+                  onClose={() => handleSelectionChange(option)}
                 >
                   {option}
                 </SelectFilterChip>


### PR DESCRIPTION
This PR address issue #861

I deleted `multiSelectOptions`, which had been used to populate the select dropdown list, and uses the options prop for the dropdown list instead.

`multiSelectOptions` was being used so that selected items would be removed from the dropdown list when they were selected. Now, with options being used for the dropdown list, selected items remain in the list with a checkmark to show that they have been selected (this is the default behavior for NextUI's select component).

The change in DimensionFilter.tsx is to address some unexpected behavior I ran into after making the above change.  First, de-selecting all options from the dropdown list would create a filter option of `""`, which would create an empty pill in the select bar and prevent any properties from being displayed on the map.  Second, deselection options by clicking the close button on a pill would remove more properties than the de-selected option.