### PR TITLE
fix typos in a11y statement

### DIFF
--- a/src/app/(content-pages)/accessibility-statement/AccessibilityStatementPage.tsx
+++ b/src/app/(content-pages)/accessibility-statement/AccessibilityStatementPage.tsx
@@ -14,18 +14,16 @@ export default function AccessibilityStatementPage() {
         physical or cognitive abilities.
       </p>
       <h2 className="heading-2xl font-semibold mt-8">
-        Measures to support accessibility
+        Measures to Support Accessibility
       </h2>
       <p>Our team prioritizes accessibility by:</p>
       <ul className="list-disc ml-8 my-2">
+        <li>Integrating accessibility as part of the design process</li>
+        <li>Integrating accessibility in the development process</li>
+        <li>Utilizing automated accessibility tools as part of our testing</li>
         <li>
-          Integrating accessibility as part of the design process Integrating
-        </li>
-        <li>accessibility in the development process Utilizing automated</li>
-        <li>accessibility tools as part of our testing Designating an</li>
-        <li>
-          Accessibility Specialist that serves as a resource for our
-          contributors
+          Designating an Accessibility Specialist that serves as a resource for
+          our contributors
         </li>
       </ul>
       <h2 className="heading-2xl font-semibold mt-8">Conformance Status</h2>


### PR DESCRIPTION
- Fixed typos and wording in Accessibility Statement Page.
### Screenshot

<img width="621" alt="fix-typos-857" src="https://github.com/user-attachments/assets/f63c0538-f815-4dbc-bc43-54a3d47b6178">

Closes #857 