### PR TITLE
Remove hr from Screen Reader

### DIFF
--- a/src/app/(content-pages)/accessibility-statement/AccessibilityStatementPage.tsx
+++ b/src/app/(content-pages)/accessibility-statement/AccessibilityStatementPage.tsx
@@ -119,8 +119,7 @@ export default function AccessibilityStatementPage() {
         </Link>
         )
       </p>
-      <hr className="my-6 border-gray-300" />
-
+      <hr className="my-6 border-gray-300" aria-hidden="true" />
       <p>This statement was created on June 10, 2024.</p>
     </>
   );


### PR DESCRIPTION
- Added aria-hidden="true" to `<hr>` element on a11y statement page.

<img width="841" alt="858-hr-hidden" src="https://github.com/user-attachments/assets/e591bdda-e3bf-41dd-8d18-4e583af37032">

Closes #858 