### PR TITLE
fix footer a11y issue

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -20,28 +20,34 @@ const Footer = () => {
               <span className="base-sm text-gray-600">
                 © 2024 Clean & Green Philly
               </span>
+              <span className="max-sm:hidden pl-2 pr-1" aria-hidden="true">
+                —
+              </span>
             </li>
 
-            <span className="max-sm:hidden">—</span>
-
-            <li className="base-sm underline text-gray-600 mx-auto">
+            <li className="base-sm  text-gray-600 mx-auto">
               <a
-                className="hover:text-gray-800 cursor-pointer"
+                className="hover:text-gray-800 cursor-pointer underline"
                 onClick={onClickCookieSettings}
               >
                 Cookie Settings
               </a>
+              <span className="max-sm:hidden pl-2 pr-1" aria-hidden="true">
+                —
+              </span>
             </li>
 
-            <span className="max-sm:hidden">—</span>
-
-            <li className="base-sm underline text-gray-600 mx-auto">
-              <Link href="/legal-disclaimer" className="hover:text-gray-800">
+            <li className="base-sm text-gray-600 mx-auto">
+              <Link
+                href="/legal-disclaimer"
+                className="hover:text-gray-800 underline"
+              >
                 Legal Disclaimer
               </Link>
+              <span className="max-sm:hidden pl-2 pr-1" aria-hidden="true">
+                —
+              </span>
             </li>
-
-            <span className="max-sm:hidden">—</span>
 
             <li>
               <a
@@ -50,9 +56,10 @@ const Footer = () => {
               >
                 Contact Us
               </a>
+              <span className="max-sm:hidden pl-2 pr-1" aria-hidden="true">
+                —
+              </span>
             </li>
-
-            <span className="max-sm:hidden">—</span>
 
             <li className="base-sm underline text-gray-600 mx-auto">
               <Link


### PR DESCRIPTION
- Fixed issues regarding footer accessibility: `<ul>` only contains `<li>` elements; `aria-hidden="true"` for dashes

### Screenshots:
<img width="1266" alt="aria-hidden-dash" src="https://github.com/user-attachments/assets/c82ca391-553b-4063-8a26-72a4e36b5994">
<img width="1290" alt="footer-fixed-a11y-score" src="https://github.com/user-attachments/assets/45dcfcd6-163b-4423-966c-22c0d01b9f1a">
<img width="368" alt="mobile-no-dash-png" src="https://github.com/user-attachments/assets/945bc833-29e7-42aa-9f7e-1afd80c30ac8">

Closes #856.



