### PR TITLE
Fix GitHub repository link redirect issue on Methodology page (#878)

### DIFF
--- a/src/app/(content-pages)/methodology/MethodologyPage.tsx
+++ b/src/app/(content-pages)/methodology/MethodologyPage.tsx
@@ -262,7 +262,7 @@ export default function MethodologyPage() {
         <p className="body-md mb-4">
           Documentation of the data that we use is available on{' '}
           <a
-            href="https://github.com/CodeForPhilly/vacant-lots-proj"
+            href="https://github.com/CodeForPhilly/clean-and-green-philly"
             target="_blank"
             rel="noopener noreferrer"
             className="link"

--- a/src/app/(content-pages)/methodology/MethodologyPage.tsx
+++ b/src/app/(content-pages)/methodology/MethodologyPage.tsx
@@ -262,7 +262,7 @@ export default function MethodologyPage() {
         <p className="body-md mb-4">
           Documentation of the data that we use is available on{' '}
           <a
-            href="https://www.figma.com/exit?url=https%3A%2F%2Fgithub.com%2FCodeForPhilly%2Fvacant-lots-proj"
+            href="https://github.com/CodeForPhilly/vacant-lots-proj"
             target="_blank"
             rel="noopener noreferrer"
             className="link"


### PR DESCRIPTION
### Summary
This PR addresses issue #878 where the GitHub repository link on the Methodology page was incorrectly redirecting users to a Figma page. The link now correctly directs users straight to the GitHub repository without the intermediate Figma redirect.

### Changes Made
- Updated the hyperlink under the Data Sources header on the Methodology page to point directly to the GitHub repository