### PR TITLE
Azbl/875 Fix and hyperlink PA horticultural society on homepage.

### DIFF
--- a/src/app/(content-pages)/page.tsx
+++ b/src/app/(content-pages)/page.tsx
@@ -139,7 +139,7 @@ const LandingPage: FC = () => {
             text: 'Community groups and organizations are taking action.',
           }}
           body={{
-            text: 'Community groups have been cleaning up lots in their own neighborhoods for decades. Large organizations like the Pennsylvania Horticulture Society have cleaned, greened and now maintain thousands of lots. Their efforts have been instrumental in proving this approach works.',
+            text: 'Community groups have been cleaning up lots in their own neighborhoods for decades. Large organizations like the Pennsylvania Horticultural Society have cleaned, greened and now maintain thousands of lots. Their efforts have been instrumental in proving this approach works.',
           }}
           image={{
             data: imageCleaning,

--- a/src/app/(content-pages)/page.tsx
+++ b/src/app/(content-pages)/page.tsx
@@ -142,7 +142,7 @@ const LandingPage: FC = () => {
             text: (
               <>
                 Community groups have been cleaning up lots in their own
-                neighborhoods for decades. Large organizations like the
+                neighborhoods for decades. Large organizations like the{' '}
                 <a
                   target="_blank"
                   rel="noopener noreferrer nofollow"

--- a/src/app/(content-pages)/page.tsx
+++ b/src/app/(content-pages)/page.tsx
@@ -139,7 +139,22 @@ const LandingPage: FC = () => {
             text: 'Community groups and organizations are taking action.',
           }}
           body={{
-            text: 'Community groups have been cleaning up lots in their own neighborhoods for decades. Large organizations like the Pennsylvania Horticultural Society have cleaned, greened and now maintain thousands of lots. Their efforts have been instrumental in proving this approach works.',
+            text: (
+              <>
+                Community groups have been cleaning up lots in their own
+                neighborhoods for decades. Large organizations like the
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer nofollow"
+                  href="https://phsonline.org/"
+                  className="default"
+                >
+                  Pennsylvania Horticultural Society
+                </a>{' '}
+                have cleaned, greened and now maintain thousands of lots. Their
+                efforts have been instrumental in proving this approach works.
+              </>
+            ),
           }}
           image={{
             data: imageCleaning,


### PR DESCRIPTION
This request:

1. Changes Pennsylvania Horticulture Society to Pennsylvania Horticultural Society on homepage.
2. Creates a hyperlink for the text Pennsylvania Horticultural Society to https://phsonline.org/