### PR TITLE
Fix for a glitch caused by changes to PHS data

### DIFF
--- a/data/src/constants/services.py
+++ b/data/src/constants/services.py
@@ -10,8 +10,7 @@ CITY_OWNED_PROPERTIES_TO_LOAD = [
 ]
 
 PHS_LAYERS_TO_LOAD = [
-    "https://services.arcgis.com/fLeGjb7u4uXqeF9q/ArcGIS/rest/services/PHS_CommunityLandcare/FeatureServer/0/",
-    "https://services.arcgis.com/fLeGjb7u4uXqeF9q/ArcGIS/rest/services/PHS_PhilaLandCare_Maintenance/FeatureServer/0/",
+    "https://services.arcgis.com/fLeGjb7u4uXqeF9q/ArcGIS/rest/services/phs_landcare/FeatureServer/0",
 ]
 
 RCOS_LAYERS_TO_LOAD = [

--- a/data/src/data_utils/phs_properties.py
+++ b/data/src/data_utils/phs_properties.py
@@ -1,23 +1,33 @@
 from classes.featurelayer import FeatureLayer
 from constants.services import PHS_LAYERS_TO_LOAD
 
+def phs_properties(primary_featurelayer: FeatureLayer) -> FeatureLayer:
+    """
+    Perform a spatial join between the primary feature layer and the PHS properties layer,
+    then update the primary feature layer with a new column 'phs_care_program' indicating
+    if the property is part of the PHS care program.
 
-def phs_properties(primary_featurelayer):
+    Args:
+        primary_featurelayer (FeatureLayer): The primary feature layer to join with the PHS properties layer.
+
+    Returns:
+        FeatureLayer: The updated primary feature layer with the 'phs_care_program' column.
+    """
+    
     phs_properties = FeatureLayer(
-        name="PHS Properties", esri_rest_urls=PHS_LAYERS_TO_LOAD, cols=["BRT_ID"]
+        name="PHS Properties", esri_rest_urls=PHS_LAYERS_TO_LOAD, cols=["program"]
     )
 
-    phs_properties.gdf.loc[:, "phs_partner_agency"] = "PHS"
+    # Perform spatial join between primary feature layer and PHS properties
+    primary_featurelayer.spatial_join(phs_properties)
 
-    primary_featurelayer.opa_join(
-        phs_properties.gdf,
-        "brt_id",
-    )
+    # Initialize 'phs_care_program' column with default "no" for all rows
+    primary_featurelayer.gdf["phs_care_program"] = "no"
+    
+    # Set 'phs_care_program' to "yes" for matched rows
+    primary_featurelayer.gdf.loc[primary_featurelayer.gdf["phs_care_program"] != "no", "phs_care_program"] = "yes"
 
-    primary_featurelayer.gdf.loc[:, "phs_partner_agency"] = primary_featurelayer.gdf[
-        "phs_partner_agency"
-    ].fillna("None")
-
+    # Rebuild the GeoDataFrame after updates
     primary_featurelayer.rebuild_gdf()
 
     return primary_featurelayer

--- a/data/src/data_utils/priority_level.py
+++ b/data/src/data_utils/priority_level.py
@@ -5,7 +5,7 @@ def priority_level(dataset):
 
         # Decision Points
         guncrime_density_percentile = row["gun_crimes_density_percentile"]
-        in_phs_landcare = row["phs_partner_agency"] == "PHS"
+        in_phs_landcare = row["phs_care_program"] == "yes"
         has_li_complaint_or_violation = (
             row["li_complaints"] is not None
             and float(row["all_violations_past_year"]) > 0


### PR DESCRIPTION
The PHS land care and community land care datasets have been merged into a single dataset. This fix updates our `constants` file to reflect the new URL, and also changes the priority level ranking to use a spatial join instead of opa join, since the PHS data no longer include OPA ID (this is annoying). 