### PR TITLE
663 checkbox behavior

### DIFF
--- a/src/components/Filters/ButtonGroup.tsx
+++ b/src/components/Filters/ButtonGroup.tsx
@@ -7,6 +7,7 @@ import { Check } from '@phosphor-icons/react';
 type ButtonGroupProps = {
   options: string[];
   selectedKeys: string[];
+  aria_describedby_label?: string;
   toggleDimension: (dimension: string) => void;
   displayOptions?: { [key: string]: string };
 };
@@ -15,6 +16,7 @@ const ButtonGroup: FC<ButtonGroupProps> = ({
   options,
   selectedKeys,
   toggleDimension,
+  aria_describedby_label,
   displayOptions = {},
 }) => {
   return (
@@ -23,6 +25,7 @@ const ButtonGroup: FC<ButtonGroupProps> = ({
         <Button
           key={index}
           disableAnimation
+          role="checkbox"
           onPress={() => toggleDimension(option)}
           size="sm"
           color={selectedKeys.includes(option) ? 'success' : 'default'}
@@ -33,7 +36,8 @@ const ButtonGroup: FC<ButtonGroupProps> = ({
               : '')
           }
           radius="full"
-          aria-pressed={selectedKeys.includes(option)}
+          aria-checked={selectedKeys.includes(option)}
+          aria-describedby={aria_describedby_label}
           startContent={
             selectedKeys.includes(option) ? (
               <Check className="w-3 w-3.5 max-h-6" />

--- a/src/components/Filters/DimensionFilter.tsx
+++ b/src/components/Filters/DimensionFilter.tsx
@@ -116,6 +116,7 @@ const DimensionFilter: FC<DimensionFilterProps> = ({
           selectedKeys={selectedKeys}
           toggleDimension={toggleDimension}
           displayOptions={optionsDisplayMapping[property]}
+          aria_describedby_label={filterLabelID}
         />
       );
     } else if (type === 'panels') {
@@ -137,6 +138,7 @@ const DimensionFilter: FC<DimensionFilterProps> = ({
           selectedKeys={selectedKeys}
           toggleDimension={toggleDimension}
           handleSelectionChange={handleSelectionChange}
+          aria_describedby_label={filterLabelID}
         />
       );
     }

--- a/src/components/Filters/MultiSelect.tsx
+++ b/src/components/Filters/MultiSelect.tsx
@@ -13,6 +13,7 @@ type MultiSelectProps = {
   display: string;
   options: any[];
   selectedKeys: string[];
+  aria_describedby_label?: string;
   toggleDimension: (dimension: string) => void;
   handleSelectionChange: (
     selection: React.ChangeEvent<HTMLSelectElement> | string
@@ -23,13 +24,14 @@ const MultiSelect: FC<MultiSelectProps> = ({
   display,
   options,
   selectedKeys,
+  aria_describedby_label,
   toggleDimension,
   handleSelectionChange,
 }) => {
   return (
     <div className="space-x-2 min-h-[33.5px]">
       <SelectFilter
-        aria-label={display}
+        aria-describedby={aria_describedby_label}
         items={options}
         variant="flat"
         size="md"

--- a/src/components/Filters/Panels.tsx
+++ b/src/components/Filters/Panels.tsx
@@ -88,7 +88,7 @@ const Panels: FC<PanelsProps> = ({
         key={index}
         role="checkbox"
         aria-describedby={aria_describedby_label}
-        aria-checked={isSelected ? 'true' : 'false'}
+        aria-checked={isSelected}
         className={isSelected ? 'panelSelected ' : 'panelDefault'}
         isPressable
         onPress={() => toggleDimensionForPanel(panel.dimension, panel.property)}


### PR DESCRIPTION
This resolves issue https://github.com/CodeForPhilly/clean-and-green-philly/issues/663

- role of checkbox added to the button group elements
- aria-describedby is used to tie in heading to the checkbox element and the multi-select
<img width="1786" alt="Screen Shot 2024-11-03 at 2 42 13 PM" src="https://github.com/user-attachments/assets/31b00a34-4f9a-4c68-bb66-68ae709d3c61">
<img width="1755" alt="Screen Shot 2024-11-03 at 2 42 06 PM" src="https://github.com/user-attachments/assets/4bafc045-5bcf-4a8b-a49b-eecc38797403">
<img width="1699" alt="Screen Shot 2024-11-03 at 2 42 40 PM" src="https://github.com/user-attachments/assets/290d05c3-81c7-4b52-b019-d2fe0899e904">
