### PR TITLE
Adds Button To Change Map Style

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,7 @@
     "sourceType": "module",
     "project": "./tsconfig.json"
   },
+  "root": true,
   "extends": [
     "next/core-web-vitals",
     "plugin:react/recommended",

--- a/src/app/find-properties/[[...opa_id]]/page.tsx
+++ b/src/app/find-properties/[[...opa_id]]/page.tsx
@@ -294,7 +294,6 @@ const MapPage = ({ params }: MapPageProps) => {
                 featuresInView={featuresInView}
                 display={currentView as 'detail' | 'list'}
                 loading={loading}
-                hasLoadingError={hasLoadingError}
                 selectedProperty={selectedProperty}
                 setSelectedProperty={setSelectedProperty}
                 setIsStreetViewModalOpen={setIsStreetViewModalOpen}

--- a/src/components/PropertyDetailSection.tsx
+++ b/src/components/PropertyDetailSection.tsx
@@ -42,7 +42,6 @@ interface PropertyDetailSectionProps {
   featuresInView: MapGeoJSONFeature[];
   display: 'detail' | 'list';
   loading: boolean;
-  hasLoadingError: boolean;
   selectedProperty: MapGeoJSONFeature | null;
   setSelectedProperty: (property: MapGeoJSONFeature | null) => void;
   setIsStreetViewModalOpen: Dispatch<SetStateAction<boolean>>;
@@ -56,7 +55,6 @@ const PropertyDetailSection: FC<PropertyDetailSectionProps> = ({
   featuresInView,
   display,
   loading,
-  hasLoadingError,
   selectedProperty,
   setSelectedProperty,
   setIsStreetViewModalOpen,
@@ -166,16 +164,7 @@ const PropertyDetailSection: FC<PropertyDetailSectionProps> = ({
     return featuresInView.slice(start, end);
   }, [page, featuresInView, smallScreenMode]);
 
-  return hasLoadingError ? (
-    <div className="flex flex-col w-full items-center justify-center p-4 mt-24">
-      <div>
-        <p className="body-md">We are having technical issues.</p>
-      </div>
-      <div>
-        <p className="body-md">Please try again later.</p>
-      </div>
-    </div>
-  ) : loading ? (
+  return loading ? (
     <div className="flex-grow h-full">
       {/* Center vertically in screen */}
       <div className="flex w-full justify-center p-4 mt-24">

--- a/src/components/PropertyMap.tsx
+++ b/src/components/PropertyMap.tsx
@@ -1,5 +1,5 @@
 'use client';
-
+import '../components/components-css/PropertyMap.css';
 import {
   FC,
   useEffect,
@@ -46,7 +46,7 @@ import '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css';
 import { MapLegendControl } from './MapLegendControl';
 import { createPortal } from 'react-dom';
 import { Tooltip } from '@nextui-org/react';
-import { Info, X } from '@phosphor-icons/react';
+import { Info, MapPinArea, X } from '@phosphor-icons/react';
 import { centroid } from '@turf/centroid';
 import { Position } from 'geojson';
 import { toTitleCase } from '../utilities/toTitleCase';
@@ -106,6 +106,21 @@ const layerStylePoints: CircleLayerSpecification = {
   },
 };
 
+const mapStyles = [
+  {
+    name: 'Data Visualization View',
+    url: `https://api.maptiler.com/maps/dataviz/style.json?key=${maptilerApiKey}`,
+  },
+  {
+    name: 'Sattelite View',
+    url: `https://api.maptiler.com/maps/hybrid/style.json?key=${maptilerApiKey}`,
+  },
+  {
+    name: 'Street View',
+    url: `https://api.maptiler.com/maps/streets/style.json?key=${maptilerApiKey}`,
+  },
+];
+
 // info icon in legend summary
 let summaryInfo: ReactElement | null = null;
 
@@ -164,6 +179,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
   const { appFilter } = useFilter();
   const [popupInfo, setPopupInfo] = useState<any | null>(null);
   const [map, setMap] = useState<MaplibreMap | null>(null);
+  const [currentStyle, setCurrentStyle] = useState<number>(0);
   const geocoderRef = useRef<MapboxGeocoder | null>(null);
   const [searchedProperty, setSearchedProperty] = useState<SearchedProperty>({
     coordinates: [-75.1628565788269, 39.97008211622267],
@@ -181,6 +197,10 @@ const PropertyMap: FC<PropertyMapProps> = ({
 
   const onMapClick = (e: MapMouseEvent) => {
     handleMapClick(e.lngLat);
+  };
+
+  const handleStyleChange = () => {
+    setCurrentStyle((prevStyle) => (prevStyle + 1) % mapStyles.length);
   };
 
   const moveMap = (targetPoint: LngLatLike) => {
@@ -421,11 +441,56 @@ const PropertyMap: FC<PropertyMapProps> = ({
     if (map) {
       updateFilter();
     }
-  }, [map, appFilter]);
+  }, [map, appFilter, currentStyle]);
 
   const changeCursor = (e: any, cursorType: 'pointer' | 'default') => {
     e.target.getCanvas().style.cursor = cursorType;
   };
+
+  map?.on('load', () => {
+    console.log('Map loaded, checking layers...');
+
+    if (!map.getLayer('vacant_properties_tiles_points')) {
+      map.addLayer(layerStylePoints);
+    }
+    if (!map.getLayer('vacant_properties_tiles_polygons')) {
+      map.addLayer(layerStylePolygon);
+    }
+
+    if (
+      map.getLayer('vacant_properties_tiles_points') &&
+      map.getLayer('vacant_properties_tiles_polygons')
+    ) {
+      console.log('Both layers found, applying filters...');
+
+      const mapFilter = Object.entries(appFilter).reduce(
+        (acc, [property, filterItem]) => {
+          if (filterItem.values.length) {
+            const thisFilterGroup: any = ['any'];
+            filterItem.values.forEach((item) => {
+              if (filterItem.useIndexOfFilter) {
+                thisFilterGroup.push([
+                  '>=',
+                  ['index-of', item, ['get', property]],
+                  0,
+                ]);
+              } else {
+                thisFilterGroup.push(['in', ['get', property], item]);
+              }
+            });
+            acc.push(thisFilterGroup);
+          }
+          return acc;
+        },
+        [] as any[]
+      );
+
+      map.setFilter('vacant_properties_tiles_points', ['all', ...mapFilter]);
+      map.setFilter('vacant_properties_tiles_polygons', ['all', ...mapFilter]);
+    } else {
+      console.warn('Layers not found, skipping filter application.');
+    }
+  });
 
   // map load
   return (
@@ -433,7 +498,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
       <Map
         mapLib={maplibregl as any}
         initialViewState={initialViewState}
-        mapStyle={`https://api.maptiler.com/maps/dataviz/style.json?key=${maptilerApiKey}`}
+        mapStyle={mapStyles[currentStyle].url}
         onMouseEnter={(e) => changeCursor(e, 'pointer')}
         onMouseLeave={(e) => changeCursor(e, 'default')}
         onClick={onMapClick}
@@ -452,6 +517,13 @@ const PropertyMap: FC<PropertyMapProps> = ({
         onMoveEnd={handleSetFeatures}
       >
         <MapControls />
+        <button
+          className={'map-style-button'}
+          title={'Change Map Style'}
+          onClick={() => handleStyleChange()}
+        >
+          <MapPinArea />
+        </button>
         {popupInfo && (
           <Popup
             className="customized-map-popup"

--- a/src/components/components-css/PropertyMap.css
+++ b/src/components/components-css/PropertyMap.css
@@ -1,0 +1,16 @@
+.map-style-button {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 1;
+  padding: 10px 15px;
+  background: white;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.map-style-button:hover {
+  background: #e0e0e0;
+}


### PR DESCRIPTION
## **Description**
This PR introduces a button in the top-left corner of the **Find Properties** map. The button allows users to toggle between the three currently enabled map styles.

---

## **Steps to Test**

1. Navigate to the **Find Properties** tab.
2. Verify that a button with a pin icon appears in the top-left corner of the map.
3. Click the button to cycle through the three available map styles.
4. Ensure the property list loads as expected.
5. Confirm the map functionality remains consistent with previous behavior.

---

## **Screenshots**
file:///home/donovan/Videos/Screencasts/Screencast%20from%2012-14-2024%2004:17:22%20PM.webm

