### PR TITLE
Hides extra map elements

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -199,6 +199,7 @@
 
 #main .maplibregl-ctrl-bottom-left {
   left: 20px;
+  padding-bottom: 10px;
   pointer-events: bounding-box;
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -198,7 +198,7 @@
 }
 
 #main .maplibregl-ctrl-bottom-left {
-  left: 20px;
+  left: 10px;
   padding-bottom: 10px;
   pointer-events: bounding-box;
 }

--- a/src/components/PropertyMap.tsx
+++ b/src/components/PropertyMap.tsx
@@ -8,6 +8,7 @@ import {
   Dispatch,
   SetStateAction,
   ReactElement,
+  ElementRef,
 } from 'react';
 import {
   maptilerApiKey,
@@ -444,7 +445,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
         }}
         onLoad={(e) => {
           setMap(e.target);
-          const attributionButton = document.querySelector(
+          const attributionButton: HTMLElement | null = document.querySelector(
             '.maplibregl-ctrl-attrib-button'
           );
           if (attributionButton) {

--- a/src/components/PropertyMap.tsx
+++ b/src/components/PropertyMap.tsx
@@ -115,7 +115,6 @@ const MapControls = () => {
     <>
       <NavigationControl showCompass={false} position="bottom-right" />
       <GeolocateControl position="bottom-right" />
-      <ScaleControl />
       {smallScreenToggle || window.innerWidth > 640 ? (
         <MapLegendControl
           position="bottom-left"
@@ -445,6 +444,14 @@ const PropertyMap: FC<PropertyMapProps> = ({
         }}
         onLoad={(e) => {
           setMap(e.target);
+          const attributionButton = document.querySelector(
+            '.maplibregl-ctrl-attrib-button'
+          );
+          if (attributionButton) {
+            attributionButton.click();
+          } else {
+            console.warn('Attribution button not found.');
+          }
         }}
         onSourceData={(e) => {
           handleSetFeatures(e);


### PR DESCRIPTION
## **Description**
This PR removes the map scale on the bottom left of the property map and hides the map attribute on the bottom right of the map by default.  Addresses [(Issue#1022)](https://github.com/CodeForPhilly/clean-and-green-philly/issues/1022#issuecomment-2543404412) 

---

## **Steps to Test**

1. Navigate to the Property Map
2. You should not see the map scale on the bottom left corner of the map just the map legend
3. The attribution on the bottom right should be hidden when the application loads
---

## **Screenshots**
![Screenshot from 2024-12-18 11-23-06](https://github.com/user-attachments/assets/f27b4a7c-be4e-431a-8a3e-ae9358c29636)




