### PR TITLE
Fixes aria error

### DIFF
--- a/src/components/ThemeButton.tsx
+++ b/src/components/ThemeButton.tsx
@@ -7,7 +7,6 @@ type ButtonProps = Omit<NextUIButtonProps, 'color'> & {
   label?: string | React.ReactNode;
   color?: 'primary' | 'secondary' | 'tertiary';
   isSelected?: boolean;
-  ariaCurrent?: boolean;
 };
 
 type Ref = HTMLButtonElement;
@@ -94,7 +93,6 @@ const ThemeButton = forwardRef<Ref, ButtonProps>(function ThemeButton(
     ? `cursor-not-allowed ${removedTransitionStyles}`
     : '';
   const iconStyles = 'w-5 h-5 text-xl';
-  const ariaCurrent = isSelected ? { 'aria-current': 'true' } : {};
 
   return (
     <NextUIButton
@@ -104,8 +102,6 @@ const ThemeButton = forwardRef<Ref, ButtonProps>(function ThemeButton(
       size="md"
       className={`${basedStyles}  ${colorStyles} ${padding} ${disabledStyles} ${className}`}
       ref={ref}
-      aria-disabled={isDisabled}
-      ariaCurrent
       startContent={
         startContent ? (
           <span className={iconStyles}>{startContent}</span>

--- a/src/components/ThemeButton.tsx
+++ b/src/components/ThemeButton.tsx
@@ -97,6 +97,8 @@ const ThemeButton = forwardRef<Ref, ButtonProps>(function ThemeButton(
   return (
     <NextUIButton
       disableRipple={isDisabled}
+      aria-disabled={isDisabled}
+      aria-current
       onPress={isDisabled ? undefined : onPress}
       isIconOnly={iconOnly}
       size="md"


### PR DESCRIPTION
Description
This PR resolves an error that occurs when opening the app.

Error:
Warning: Invalid ARIA attribute 'ariaCurrent'. Did you mean 'aria-current'?

Cause:
The error is linked to an issue detailed in [NextUI v2.6.0](https://nextui.org/blog/v2.6.0).

Steps to Test
Launch the app.
Check the console log for errors.
Confirm that the ariaCurrent warning no longer appears.