### PR TITLE
Allow hover styles on screens below 640px

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,8 +4,7 @@
 
 @font-face {
   font-family: 'HK Grotesk';
-  src:
-    url('/fonts/hkgrotesk-bold-webfont.woff2') format('woff2'),
+  src: url('/fonts/hkgrotesk-bold-webfont.woff2') format('woff2'),
     url('/fonts/hkgrotesk-bold-webfont.woff') format('woff');
   font-weight: bold;
   font-style: normal;
@@ -13,8 +12,7 @@
 
 @font-face {
   font-family: 'HK Grotesk';
-  src:
-    url('/fonts/hkgrotesk-extrabold-webfont.woff2') format('woff2'),
+  src: url('/fonts/hkgrotesk-extrabold-webfont.woff2') format('woff2'),
     url('/fonts/hkgrotesk-extrabold-webfont.woff') format('woff');
   font-weight: 800;
   font-style: normal;
@@ -22,8 +20,7 @@
 
 @font-face {
   font-family: 'HK Grotesk';
-  src:
-    url('/fonts/hkgrotesk-regular-webfont.woff2') format('woff2'),
+  src: url('/fonts/hkgrotesk-regular-webfont.woff2') format('woff2'),
     url('/fonts/hkgrotesk-regular-webfont.woff') format('woff');
   font-weight: normal;
   font-style: normal;
@@ -147,7 +144,7 @@
   /* added webkit transform to remove icon movement in safari */
 
   .iconLink {
-    @apply text-gray-900 items-center active:bg-gray-100 active:text-green-700 focus:text-green-700 focus:bg-green-100 bg-color-none hover:bg-gray-10 rounded-medium max-sm:hover:bg-gray-0;
+    @apply text-gray-900 items-center active:bg-gray-100 active:text-green-700 focus:text-green-700 focus:bg-green-100 bg-color-none hover:bg-gray-10 rounded-medium;
     transform: translateZ(0);
     -webkit-transform: translateZ(0);
   }


### PR DESCRIPTION
## Why
Changes requested in #1079 to unify mobile styles across screenwidths. 

## What
Hover styles for the mobile menu items below the `max-sm` screenwidth (640px) were being overridden by a tailwind rule applied to the `iconLink` css class. Removing that rule restored them.

## Screen captures demonstrating existing and modified behavior
#### Current behavior in production:
https://github.com/user-attachments/assets/436f2ff8-1924-4e01-8817-c6fbd44c7b33

#### Modified behavior with this change:
https://github.com/user-attachments/assets/abdc9c0e-c6a5-433c-9b00-7acfd27cdf24

## Testing steps
### Observe existing behavior
1. Navigate to the prod site at https://www.cleanandgreenphilly.org/
2. Observe the site at a screenwidth of more than 640px, and less than 850px.
3. Click on the mobile nav toggle (the hamburger icon in the nav bar)
4. With the mobile nav open, hover over the nav items. There should be a light gray background behind items.
5. Observe the site at a screenwidth of less than 640px
6. Open the mobile nav again as above, and hover over the menu items
7. There should be no background visible on the menu item while hovering
### Observe modified behavior
1. Build this code locally
2. Navigate to the local site at `localhost:3000` (or whichever port you're using if other)
3. Observe the site at a screenwidth of less than 640px
4. Click on the hamburger icon to open the mobile menu
5. Hover over menu items
6. Menu items should show a light gray background on hover, as observed above at screenwidth > 640px and less than 850px.

