### PR TITLE
TASK [#1090] : Stop GitHub Actions from adding "stale" labels to issues

### DIFF
--- a/.github/workflows/flag-stale.yml
+++ b/.github/workflows/flag-stale.yml
@@ -20,7 +20,7 @@ jobs:
           days-before-stale: 7
           stale-pr-message: 'This PR has been marked as stale because it has been open for 7 days with no activity.'
           stale-pr-label: 'stale'
-          days-before-issue-stale: 30
+          days-before-issue-stale: -1
           stale-issue-message: 'This issue has been marked as stale because it has been open for 30 days with no activity.'
           stale-issue-label: 'stale'
           days-before-close: -1


### PR DESCRIPTION
#1090 
Updated the [flag-stale.yml](https://github.com/CodeForPhilly/clean-and-green-philly/blob/main/.github/workflows/flag-stale.yml) file to stop adding the 'stale' label to issues.