### PR TITLE
Bugfix - prevent losing focus when filtering

### DIFF
--- a/src/components/SidePanelControlBar.tsx
+++ b/src/components/SidePanelControlBar.tsx
@@ -80,7 +80,7 @@ const SearchBarComponent: FC<SidePanelControlBarProps> = ({
         closeButton.focus();
       }
     }
-  });
+  }, [currentView]);
 
   return loading ? (
     <div>{/* Keep empty while loading */}</div>


### PR DESCRIPTION
### Description
This PR fixes a bug, #1024, where clicking on filtering options from the Find Properties page causes the focus to move to the top.

### Cause of the Bug
Not having currentView in the dependency array caused the useEffect to run on every render. Adding currentView as a dependency ensures that the re-render is triggered only when the currentView state changes.

### Steps to Test
1. Navigate to 'Find Properties'
2. Click on the 'Filter' button
3. If you click on any filtering action on the page, the focus should remain at the point where the action occurred.

### Screen Recording


https://github.com/user-attachments/assets/2290409e-a431-4340-bf73-c59cf94a26ab

