### PR TITLE
Task 1089 remove inactive reviewer

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -14,7 +14,7 @@ useReviewGroups: true
 # A list of reviewers, split into different groups, to be added to pull requests (GitHub user name)
 reviewGroups:
   backend:
-    - zigouras
+    - null
   frontend:
     - CodeWritingCow
 


### PR DESCRIPTION
Removes an inactive reviewer to prevent unnecessary notifications.

Uses `null` instead of entirely deleting the line to allow for easier future modifications.

Closes #1089 .