### PR TITLE
Fix: Closing tooltip popup on map closes property details

### DIFF
--- a/src/components/PropertyMap.tsx
+++ b/src/components/PropertyMap.tsx
@@ -426,6 +426,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
   const handlePopupClose = () => {
     setSelectedProperty(null);
     setPopupInfo(null);
+    history.replaceState(null, '', `/find-properties`);
   };
 
   // map load

--- a/src/components/PropertyMap.tsx
+++ b/src/components/PropertyMap.tsx
@@ -340,7 +340,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
   useEffect(() => {
     if (!map) return;
     if (!selectedProperty) {
-      // setPopupInfo(null);
+      setPopupInfo(null);
       if (window.innerWidth < 640 && prevCoordinate) {
         map.setCenter(prevCoordinate as LngLatLike);
         setPrevCoordinate();
@@ -421,6 +421,11 @@ const PropertyMap: FC<PropertyMapProps> = ({
 
   const changeCursor = (e: any, cursorType: 'pointer' | 'default') => {
     e.target.getCanvas().style.cursor = cursorType;
+  };
+
+  const handlePopupClose = () => {
+    setSelectedProperty(null);
+    setPopupInfo(null);
   };
 
   // map load
@@ -515,7 +520,7 @@ const PropertyMap: FC<PropertyMapProps> = ({
             longitude={popupInfo.longitude}
             latitude={popupInfo.latitude}
             closeOnClick={false}
-            onClose={() => setPopupInfo(null)}
+            onClose={handlePopupClose}
           >
             <div className="flex flex-row items-center nowrap space-x-1">
               <span>{toTitleCase(popupInfo.feature.address)}</span>


### PR DESCRIPTION
# Pull Request Title

## Checklist:

- [x] I have opened my PR against the `staging` branch, NOT against `main`
- [ ] I've run the relevant formatting and linting tools listed in the setup docs
- [ ] I have commented hard-to-understand areas in my code
- [x] I've reviewed any merge conflicts to make sure they are resolved
- [x] My changes generate no new warnings

## Description

Initially, closing a property's tooltip popup on the map did not simultaneously navigate the right pane from property details to all properties in the current neighbourhood, or vice versa. This PR fixes that issue.

Additionally, the property ID in the URL is now removed when the property is deselected.

## Related Issue(s)

This PR addresses issue #1025 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

https://github.com/user-attachments/assets/c6eb8a90-1b94-4100-a8fd-c89f455c2c90
