### PR TITLE
Fix Postgres database dockerfile to build of the Postgis image

### DIFF
--- a/data/Dockerfile-timescale
+++ b/data/Dockerfile-timescale
@@ -1,17 +1,12 @@
-FROM postgres:16-bullseye
+FROM postgis/postgis:16-3.5
 
 ENV POSTGIS_MAJOR=3
 ENV POSTGIS_VERSION=3.5.0+dfsg-1.pgdg110+1
 ENV TIMESCALE_MAJOR=2
-ENV TIMESCALE_MINOR=17
+ENV TIMESCALE_MINOR=19
 
 RUN apt-get update \
       && apt-get install -y --no-install-recommends lsb-release curl gnupg apt-transport-https wget \
-           # ca-certificates: for accessing remote raster files;
-           #   fix: https://github.com/postgis/docker-postgis/issues/307
-           ca-certificates \
-           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
-           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       # Add timescale repository and key
       && echo "deb https://packagecloud.io/timescale/timescaledb/debian/ $(lsb_release -c -s) main" \
            | tee /etc/apt/sources.list.d/timescaledb.list \


### PR DESCRIPTION
This PR addresses #1120 and rewrites the `Dockerfile-timescale` file for building the postgres database by building off the base Postgis docker image, so that we now longer will need to manually update versioning there as was previously necessary.
