### PR TITLE
Fix: 1159 merge on opa_id in pwd_parcels

### DIFF
--- a/data/src/new_etl/data_utils/pwd_parcels.py
+++ b/data/src/new_etl/data_utils/pwd_parcels.py
@@ -5,6 +5,54 @@ from ..constants.services import PWD_PARCELS_QUERY
 from ..metadata.metadata_utils import provide_metadata
 
 
+def transform_pwd_parcels_gdf(pwd_parcels_gdf: gpd.GeoDataFrame):
+    """
+    Transforms the PWD parcels GeoDataFrame in place by dropping rows with null 'brt_id' and
+    renaming 'brt_id' to 'opa_id'.
+
+    Args:
+        gdf (gpd.GeoDataFrame): The input GeoDataFrame containing PWD parcels data.
+
+    """
+    # Drop rows with null brt_id, rename to opa_id, and validate geometries
+    pwd_parcels_gdf.dropna(subset=["brt_id"], inplace=True)
+    pwd_parcels_gdf.rename(columns={"brt_id": "opa_id"}, inplace=True)
+    pwd_parcels_gdf["geometry"] = pwd_parcels_gdf["geometry"].make_valid()
+
+    # Ensure geometries are polygons or multipolygons
+    if not all(pwd_parcels_gdf.geometry.type.isin(["Polygon", "MultiPolygon"])):
+        raise ValueError("Some geometries are not polygons or multipolygons.")
+
+
+def merge_pwd_parcels_gdf(
+    primary_featurelayer_gdf: gpd.GeoDataFrame, pwd_parcels_gdf: gpd.GeoDataFrame
+) -> gpd.GeoDataFrame:
+    # Join geometries from PWD parcels
+    # Temporarily drop geometry from the primary feature layer
+
+    # Filter PWD parcels to just the opa_ids in primary
+    opa_ids_in_primary = primary_featurelayer_gdf["opa_id"].unique()
+    pwd_subset = pwd_parcels_gdf[pwd_parcels_gdf["opa_id"].isin(opa_ids_in_primary)]
+
+    # Count how many of those are missing geometry
+    no_geometry_count = pwd_subset["geometry"].isnull().sum()
+    pwd_parcels_gdf_unique_opa_id = pwd_parcels_gdf.drop_duplicates(subset="opa_id")
+    primary_featurelayer_gdf_unique_opa_id = primary_featurelayer_gdf.drop_duplicates(
+        subset="opa_id"
+    )
+
+    pwd_parcels_gdf_indexed = pwd_parcels_gdf_unique_opa_id.set_index("opa_id")
+    merged_gdf_indexed = primary_featurelayer_gdf_unique_opa_id.set_index("opa_id")
+
+    merged_gdf_indexed.update(
+        pwd_parcels_gdf_indexed[["geometry"]],
+    )
+    merged_gdf = merged_gdf_indexed.reset_index()
+
+    print("Number of observations retaining point geometry:", no_geometry_count)
+    return merged_gdf
+
+
 @provide_metadata()
 def pwd_parcels(primary_featurelayer: FeatureLayer) -> FeatureLayer:
     """
@@ -39,40 +87,12 @@ def pwd_parcels(primary_featurelayer: FeatureLayer) -> FeatureLayer:
         cols=["brt_id"],
     )
 
-    # Drop rows with null brt_id, rename to opa_id, and validate geometries
-    pwd_parcels.gdf.dropna(subset=["brt_id"], inplace=True)
-    pwd_parcels.gdf.rename(columns={"brt_id": "opa_id"}, inplace=True)
-    pwd_parcels.gdf["geometry"] = pwd_parcels.gdf["geometry"].make_valid()
+    pwd_parcels_gdf = pwd_parcels.gdf
 
-    # Ensure geometries are polygons or multipolygons
-    if not all(pwd_parcels.gdf.geometry.type.isin(["Polygon", "MultiPolygon"])):
-        raise ValueError("Some geometries are not polygons or multipolygons.")
+    transform_pwd_parcels_gdf(pwd_parcels_gdf)
 
-    # Temporarily drop geometry from the primary feature layer
-    primary_df = primary_featurelayer.gdf.drop(columns=["geometry"])
-
-    # Join geometries from PWD parcels
-    merged_gdf = primary_df.merge(
-        pwd_parcels.gdf[["opa_id", "geometry"]],
-        on="opa_id",
-        how="left",
+    primary_featurelayer.gdf = merge_pwd_parcels_gdf(
+        primary_featurelayer.gdf, pwd_parcels_gdf
     )
 
-    # Coerce merged_gdf into a GeoDataFrame
-    merged_gdf = gpd.GeoDataFrame(
-        merged_gdf,
-        geometry="geometry",
-        crs=primary_featurelayer.gdf.crs,  # Ensure the CRS matches the original
-    )
-
-    # Log observations with no polygon geometry
-    no_geometry_count = merged_gdf["geometry"].isnull().sum()
-
-    # Retain point geometry for rows with no polygon geometry
-    merged_gdf["geometry"] = merged_gdf["geometry"].combine_first(
-        primary_featurelayer.gdf["geometry"]
-    )
-    print("Number of observations retaining point geometry:", no_geometry_count)
-
-    # Wrap the GeoDataFrame back into a FeatureLayer
-    return FeatureLayer(name=primary_featurelayer.name, gdf=merged_gdf)
+    return primary_featurelayer

--- a/data/src/test/test_data_utils.py
+++ b/data/src/test/test_data_utils.py
@@ -4,12 +4,17 @@ from io import BytesIO
 from unittest.mock import MagicMock, Mock, patch
 
 import geopandas as gpd
+import numpy as np
+from shapely.geometry import LineString, MultiPolygon, Point, Polygon
+
+from config.config import USE_CRS
 from data_utils.park_priority import get_latest_shapefile_url, park_priority
 from data_utils.ppr_properties import ppr_properties
 from data_utils.vacant_properties import vacant_properties
-from shapely.geometry import Point
-
-from config.config import USE_CRS
+from new_etl.data_utils.pwd_parcels import (
+    merge_pwd_parcels_gdf,
+    transform_pwd_parcels_gdf,
+)
 
 
 class TestDataUtils(unittest.TestCase):
@@ -170,6 +175,123 @@ class TestDataUtils(unittest.TestCase):
         Test the vacant properties layer. Simply construct the class to see if it works.
         """
         vacant_properties()
+
+    def test_pwd_parcels_merge(self):
+        """
+        This tests that the merge_pwd_parcels_gdf function correctly retains
+        existing point geometries in the primary GeoDataFrame when no better
+        geometry is available in the PWD parcels GeoDataFrame.
+        """
+
+        parcel_type_sample_data = ["Land", "Building", "Land", "Building"]
+        primary_data = {
+            "opa_id": ["0100", "0101", "0102", "0103"],
+            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2), Point(3, 3)],
+            "parcel_type": parcel_type_sample_data,
+        }
+
+        # CRS we don't use is chosen since we are just checking it doesn't change:
+        test_crs = "EPSG:2002"
+        primary_gdf = gpd.GeoDataFrame(primary_data, geometry="geometry", crs=test_crs)
+
+        # Simulate dropped rows by having a gapped index.
+        primary_gdf.index = [0, 2, 3, 5]
+
+        # Create pwd_parcels_gdf with a continuous index.
+        pwd_data = {
+            "opa_id": ["0100", "0101", "0102", "0103"],
+            "geometry": [
+                np.nan,  # For opa 0100, no better geometry
+                MultiPolygon(
+                    [Polygon([(10, 10), (20, 10), (20, 20), (10, 20)])]
+                ),  # For opa 0101, a multipolygon available
+                np.nan,
+                np.nan,
+            ],
+        }
+        pwd_gdf = gpd.GeoDataFrame(pwd_data, geometry="geometry")
+        assert list(pwd_gdf.index) == list(range(4))  # Continuous index: 0,1,2,3
+
+        # Call the merge function under test.
+        merged_gdf = merge_pwd_parcels_gdf(primary_gdf, pwd_gdf)
+
+        # Expected geometries:
+        # For opa_id "0010", we expect the multipolygon from pwd_gdf.
+        # For the other opa_id's we expect the point geometries from primary_gdf.
+        expected_geometries = {
+            "0100": primary_gdf.loc[0, "geometry"],
+            "0101": pwd_gdf.loc[1, "geometry"],  # pwd geometry used when available
+            "0102": primary_gdf.loc[3, "geometry"],
+            "0103": primary_gdf.loc[5, "geometry"],
+        }
+
+        assert merged_gdf.crs == primary_gdf.crs
+        assert merged_gdf.crs == test_crs
+
+        # Verify each row of the merged GeoDataFrame.
+        for idx, row in merged_gdf.iterrows():
+            opa_id = row["opa_id"]
+            actual_geom = row["geometry"]
+            expected_geom = expected_geometries[opa_id]
+            # Use shapely's equals() to check geometry equivalence.
+            assert actual_geom.equals(expected_geom), (
+                f"Mismatch for opa_id {opa_id}: "
+                f"expected {expected_geom}, got {actual_geom}"
+            )
+
+        opa_id_values = ["0100", "0101", "0102", "0103"]
+        data = {
+            "opa_id": opa_id_values,
+            "geometry": [expected_geometries[opa_id] for opa_id in opa_id_values],
+            "parcel_type": parcel_type_sample_data,
+        }
+        expected_df = gpd.GeoDataFrame(
+            data=data,
+            geometry="geometry",
+        )
+
+        assert expected_df.equals(merged_gdf)
+
+    def test_transform_pwd_parcels_gdf_basic(self):
+        """
+        Check the basic functionality of the transform_pwd_parcels_gdf function.
+        This function is expected to mutate the input GeoDataFrame in place.
+        It should drop rows with null 'brt_id', rename 'brt_id' to 'opa_id',
+        and ensure all geometries are valid polygons or multipolygons.
+        """
+        # Create test data
+        data = {
+            "brt_id": [None, "1234", "5678"],
+            "geometry": [
+                Polygon(
+                    [(0, 0), (1, 0), (1, 1), (0, 1)]
+                ),  # Will be dropped (null brt_id)
+                Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),  # Valid polygon
+                LineString([(0, 0), (1, 1)]),  # Invalid type (not a polygon)
+            ],
+        }
+        gdf = gpd.GeoDataFrame(data, geometry="geometry")
+
+        # Expect a ValueError because LineString is not allowed
+        with self.assertRaises(ValueError) as context:
+            transform_pwd_parcels_gdf(gdf.copy())
+
+        self.assertIn("not polygons or multipolygons", str(context.exception))
+
+        # Now fix the invalid geometry to test normal flow
+        gdf.loc[2, "geometry"] = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+
+        # Run transformation which mutates result in place
+        result = gdf.copy()
+        transform_pwd_parcels_gdf(result)
+
+        # Check the rows were filtered
+        self.assertEqual(len(result), 2)  # One row was dropped
+        self.assertNotIn("brt_id", result.columns)
+        self.assertIn("opa_id", result.columns)
+        self.assertListEqual(sorted(result["opa_id"].tolist()), ["1234", "5678"])
+        self.assertTrue(all(result.geometry.is_valid))
+        self.assertTrue(all(result.geometry.type.isin(["Polygon", "MultiPolygon"])))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously in the new ETL pipeline retained geometries would get misaligned due to mismatched indexes (gapped vs contiguous).

# merge on opa_id in pwd_parcels

## Checklist:

Before submitting your PR, please confirm that you have done the following:

- [x] I have opened my PR against the `staging` branch, NOT against `main`
- [x] I've run the relevant formatting and linting tools listed in the setup docs
- [x] I have commented hard-to-understand areas in my code
- [x] I've reviewed any merge conflicts to make sure they are resolved
- [x] My changes generate no new warnings

## Description

In the new ETL pipeline, an index with gaps was updated by a df with a continuous index by location using `combine_first` which caused geometries to get associated with the wrong properties when polygon/multi-polygons were not available.

I refactored the pwd_parcels to have additional helper functions (transform, merge) to allow easier testing.

An alternative implementation may be a bit cleaner but doesn't avoid using `combine_first` but instead uses it safely (on the same df so the index is guaranteed to be the same).

```
merged_df = primary_featurelayer_gdf_unique_opa_id.merge(
    pwd_parcels_gdf_unique_opa_id[["opa_id", "geometry"]],
    on="opa_id",
    how="left",
    suffixes=("", "_pwd")
)
# Then choose the PWD geometry where it exists, otherwise fallback:
merged_df["geometry"] = merged_df["geometry_pwd"].combine_first(merged_df["geometry"])
merged_df = merged_df.drop(columns=["geometry_pwd"])
```
If this is preferred, I can swap the code out.

## Related Issue(s)

This PR addresses closes #1159 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## How Has This Been Tested?

I added a test that fails when the bug is present. I'm running the full pipeline now and will review the results/share them with others.