### PR TITLE
Fix frontend linting workflow

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -1,7 +1,7 @@
 name: PR Checks
 
 on:
-  push:
+  pull_request:
     branches:
       - staging
 


### PR DESCRIPTION
Fixes the frontend linting workflow to actually trigger eslint and prettier check on opening PRs rather than on merge.
