### PR TITLE
[1196] Filter reset button

### DIFF
--- a/src/app/find-properties/[[...opa_id]]/page.tsx
+++ b/src/app/find-properties/[[...opa_id]]/page.tsx
@@ -288,7 +288,7 @@ const MapPage = ({ params }: MapPageProps) => {
                 </div>
               </div>
             ) : currentView === 'filter' ? (
-              <FilterView updateCurrentView={updateCurrentView} />
+              <FilterView />
             ) : (
               <PropertyDetailSection
                 featuresInView={featuresInView}

--- a/src/components/FilterView.tsx
+++ b/src/components/FilterView.tsx
@@ -21,8 +21,8 @@ const FilterView: FC<FilterViewProps> = ({ updateCurrentView }) => {
       <ThemeButton
         color="secondary"
         className="right-4 lg:right-[24px] absolute top-8 min-w-[3rem]"
-        aria-label="Close filter panel"
-        startContent={<PiX />}
+        label={'Reset'}
+        aria-label="Reset filters"
         id="close-filter-button" // Add an ID to this button
         onPress={() => {
           updateCurrentView('filter');

--- a/src/components/FilterView.tsx
+++ b/src/components/FilterView.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { FC } from 'react';
-import { PiX } from 'react-icons/pi';
 import { ThemeButton } from './ThemeButton';
 import { BarClickOptions } from '@/app/find-properties/[[...opa_id]]/page';
 import { rcos, neighborhoods, zoning } from './Filters/filterOptions';
@@ -9,12 +8,23 @@ import FilterDescription from './Filters/FilterDescription';
 import ButtonGroup from './Filters/ButtonGroup';
 import MultiSelect from './Filters/MultiSelect';
 import Panels from './Filters/Panels';
+import { useFilter } from '@/context/FilterContext';
 
 interface FilterViewProps {
   updateCurrentView: (view: BarClickOptions) => void;
 }
 
 const FilterView: FC<FilterViewProps> = ({ updateCurrentView }) => {
+  const { dispatch } = useFilter();
+
+  const onResetButtonPressed = () => {
+    dispatch({
+      type: 'CLEAR_DIMENSIONS',
+      property: 'reset',
+      dimensions: [],
+    });
+  };
+
   return (
     <div className="relative p-6">
       {/* Add ID to the close button */}
@@ -24,9 +34,7 @@ const FilterView: FC<FilterViewProps> = ({ updateCurrentView }) => {
         label={'Reset'}
         aria-label="Reset filters"
         id="close-filter-button" // Add an ID to this button
-        onPress={() => {
-          updateCurrentView('filter');
-        }}
+        onPress={onResetButtonPressed}
       />
       <div className="pt-3 pb-6">
         <FilterDescription

--- a/src/components/FilterView.tsx
+++ b/src/components/FilterView.tsx
@@ -10,11 +10,7 @@ import MultiSelect from './Filters/MultiSelect';
 import Panels from './Filters/Panels';
 import { useFilter } from '@/context/FilterContext';
 
-interface FilterViewProps {
-  updateCurrentView: (view: BarClickOptions) => void;
-}
-
-const FilterView: FC<FilterViewProps> = () => {
+const FilterView: FC = () => {
   const { dispatch } = useFilter();
 
   const onResetButtonPressed = () => {

--- a/src/components/FilterView.tsx
+++ b/src/components/FilterView.tsx
@@ -14,7 +14,7 @@ interface FilterViewProps {
   updateCurrentView: (view: BarClickOptions) => void;
 }
 
-const FilterView: FC<FilterViewProps> = ({ updateCurrentView }) => {
+const FilterView: FC<FilterViewProps> = () => {
   const { dispatch } = useFilter();
 
   const onResetButtonPressed = () => {


### PR DESCRIPTION
841d18c refactor: remove unused `updateCurrentView` callback
9ab43e0 feat: update reset button to dispatch 'CLEAR_DIMENSIONS'
4f94faf feat: change the 'X' button to say 'Reset'

# Pull Request Title

## Checklist:

Before submitting your PR, please confirm that you have done the following:

- [x] I have opened my PR against the `staging` branch, NOT against `main`
- [x] I've run the relevant formatting and linting tools listed in the setup docs
- [x] I have commented hard-to-understand areas in my code
- [x] I've reviewed any merge conflicts to make sure they are resolved
- [x] My changes generate no new warnings

## Description

This PR replaces the `X` button with a `Reset` button that dispatches an event to clear filter state

## Related Issue(s)

This PR addresses issue #1196 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## How Has This Been Tested?

https://github.com/user-attachments/assets/984f890a-fdd2-4604-947d-31c12747c4e2