### PR TITLE
External input validator

### DIFF
--- a/data/src/data_utils/city_owned_properties.py
+++ b/data/src/data_utils/city_owned_properties.py
@@ -3,7 +3,10 @@ from typing import Tuple
 import geopandas as gpd
 
 from src.validation.base import ValidationResult, validate_output
-from src.validation.city_owned_properties import CityOwnedPropertiesOutputValidator, CityOwnedPropertiesInputValidator
+from src.validation.city_owned_properties import (
+    CityOwnedPropertiesOutputValidator,
+    CityOwnedPropertiesInputValidator,
+)
 
 from ..classes.loaders import EsriLoader
 from ..constants.services import CITY_OWNED_PROPERTIES_TO_LOAD
@@ -46,7 +49,8 @@ def city_owned_properties(
         name="City Owned Properties",
         esri_urls=CITY_OWNED_PROPERTIES_TO_LOAD,
         cols=["OPABRT", "AGENCY", "SIDEYARDELIGIBLE"],
-        opa_col="opabrt", validator=CityOwnedPropertiesInputValidator()
+        opa_col="opabrt",
+        validator=CityOwnedPropertiesInputValidator(),
     )
 
     city_owned_properties, input_validation = loader.load_or_fetch()

--- a/data/src/data_utils/city_owned_properties.py
+++ b/data/src/data_utils/city_owned_properties.py
@@ -54,9 +54,6 @@ def city_owned_properties(
     )
 
     city_owned_properties, input_validation = loader.load_or_fetch()
-    print("City-Owned Properties Input:")
-    print(city_owned_properties.columns)
-    print(city_owned_properties.head())
 
     merged_gdf = opa_join(input_gdf, city_owned_properties)
 
@@ -158,9 +155,5 @@ def city_owned_properties(
     merged_gdf.loc[merged_gdf["city_owner_agency"] == "PLB", "city_owner_agency"] = (
         "Land Bank (PHDC)"
     )
-
-    print("City-Owned Properties Output:")
-    print(merged_gdf.columns)
-    print(merged_gdf.head())
 
     return merged_gdf, input_validation

--- a/data/src/data_utils/city_owned_properties.py
+++ b/data/src/data_utils/city_owned_properties.py
@@ -3,7 +3,7 @@ from typing import Tuple
 import geopandas as gpd
 
 from src.validation.base import ValidationResult, validate_output
-from src.validation.city_owned_properties import CityOwnedPropertiesOutputValidator
+from src.validation.city_owned_properties import CityOwnedPropertiesOutputValidator, CityOwnedPropertiesInputValidator
 
 from ..classes.loaders import EsriLoader
 from ..constants.services import CITY_OWNED_PROPERTIES_TO_LOAD
@@ -46,10 +46,13 @@ def city_owned_properties(
         name="City Owned Properties",
         esri_urls=CITY_OWNED_PROPERTIES_TO_LOAD,
         cols=["OPABRT", "AGENCY", "SIDEYARDELIGIBLE"],
-        opa_col="opabrt",
+        opa_col="opabrt", validator=CityOwnedPropertiesInputValidator()
     )
 
     city_owned_properties, input_validation = loader.load_or_fetch()
+    print("City-Owned Properties Input:")
+    print(city_owned_properties.columns)
+    print(city_owned_properties.head())
 
     merged_gdf = opa_join(input_gdf, city_owned_properties)
 
@@ -151,5 +154,9 @@ def city_owned_properties(
     merged_gdf.loc[merged_gdf["city_owner_agency"] == "PLB", "city_owner_agency"] = (
         "Land Bank (PHDC)"
     )
+
+    print("City-Owned Properties Output:")
+    print(merged_gdf.columns)
+    print(merged_gdf.head())
 
     return merged_gdf, input_validation

--- a/data/src/data_utils/council_dists.py
+++ b/data/src/data_utils/council_dists.py
@@ -49,9 +49,6 @@ def council_dists(
     )
 
     council_dists, input_validation = loader.load_or_fetch()
-    print("Council Districts Input:")
-    print(council_dists.columns)
-    print(council_dists.head())
 
     # Check that the required columns exist in the DataFrame
     required_columns = ["district", "geometry"]
@@ -72,7 +69,4 @@ def council_dists(
     # Drop duplicates in the primary feature layer
     merged_gdf.drop_duplicates(inplace=True)
 
-    print("Council Districts Output:")
-    print(merged_gdf.columns)
-    print(merged_gdf.head())
     return merged_gdf, input_validation

--- a/data/src/data_utils/council_dists.py
+++ b/data/src/data_utils/council_dists.py
@@ -4,7 +4,7 @@ import geopandas as gpd
 import pandas as pd
 
 from src.validation.base import ValidationResult, validate_output
-from src.validation.council_dists import CouncilDistrictsOutputValidator
+from src.validation.council_dists import CouncilDistrictsOutputValidator, CouncilDistrictsInputValidator
 
 from ..classes.loaders import EsriLoader
 from ..constants.services import COUNCIL_DISTRICTS_TO_LOAD
@@ -39,10 +39,14 @@ def council_dists(
     """
 
     loader = EsriLoader(
-        name="Council Districts", esri_urls=COUNCIL_DISTRICTS_TO_LOAD, cols=["district"]
+        name="Council Districts", esri_urls=COUNCIL_DISTRICTS_TO_LOAD, 
+        cols=["district"], validator = CouncilDistrictsInputValidator()
     )
 
     council_dists, input_validation = loader.load_or_fetch()
+    print("Council Districts Input:")
+    print(council_dists.columns)
+    print(council_dists.head())
 
     # Check that the required columns exist in the DataFrame
     required_columns = ["district", "geometry"]
@@ -63,4 +67,7 @@ def council_dists(
     # Drop duplicates in the primary feature layer
     merged_gdf.drop_duplicates(inplace=True)
 
+    print("Council Districts Output:")
+    print(merged_gdf.columns)
+    print(merged_gdf.head())
     return merged_gdf, input_validation

--- a/data/src/data_utils/council_dists.py
+++ b/data/src/data_utils/council_dists.py
@@ -4,7 +4,10 @@ import geopandas as gpd
 import pandas as pd
 
 from src.validation.base import ValidationResult, validate_output
-from src.validation.council_dists import CouncilDistrictsOutputValidator, CouncilDistrictsInputValidator
+from src.validation.council_dists import (
+    CouncilDistrictsOutputValidator,
+    CouncilDistrictsInputValidator,
+)
 
 from ..classes.loaders import EsriLoader
 from ..constants.services import COUNCIL_DISTRICTS_TO_LOAD
@@ -39,8 +42,10 @@ def council_dists(
     """
 
     loader = EsriLoader(
-        name="Council Districts", esri_urls=COUNCIL_DISTRICTS_TO_LOAD, 
-        cols=["district"], validator = CouncilDistrictsInputValidator()
+        name="Council Districts",
+        esri_urls=COUNCIL_DISTRICTS_TO_LOAD,
+        cols=["district"],
+        validator=CouncilDistrictsInputValidator(),
     )
 
     council_dists, input_validation = loader.load_or_fetch()

--- a/data/src/validation/base.py
+++ b/data/src/validation/base.py
@@ -26,7 +26,7 @@ class ValidationResult:
 class BaseValidator(ABC):
     """Base class for service-specific data validation."""
 
-    schema: pa.DataFrameSchema = None
+    schema = None
 
     def __init_subclass__(cls):
         schema = getattr(cls, "schema", None)

--- a/data/src/validation/city_owned_properties.py
+++ b/data/src/validation/city_owned_properties.py
@@ -1,5 +1,5 @@
 import geopandas as gpd
-import pandera as pa
+import pandera.pandera as pa
 from typing import Optional, Literal
 from .base import BaseValidator
 

--- a/data/src/validation/city_owned_properties.py
+++ b/data/src/validation/city_owned_properties.py
@@ -1,38 +1,65 @@
 import geopandas as gpd
 import pandera.pandas as pa
-from typing import Optional, Literal
 from .base import BaseValidator
 
+# Expecting ~7,796 records returned (within ±20% tolerance).
+# This is checked in CityOwnedPropertiesInputSchema
+expected = 7796
+lower = int(expected * 0.8)
+upper = int(expected * 1.2)
 
-class CityOwnedPropertiesSchema(pa.DataFrameModel):
-    """
-    Used for schema checks to ensure expected columns
-    are present with the correct types.
+CityOwnedPropertiesInputSchema = pa.DataFrameSchema(
+    columns = {
+        "opa_id": pa.Column(int, checks=pa.Check(lambda s: s.dropna() != "")),
+        "agency": pa.Column(str),
+        "sideyardeligible": pa.Column(
+            pa.Category,
+            checks=pa.Check.isin(["Yes", "No"])
+        ),
+        "geometry": pa.Column("geometry")
+    }, 
+    checks=pa.Check(
+        lambda df: lower <= df.shape[0] <= upper
+    ),
+    strict=True
+)
 
-    `Optional` typing means null values are allowed.
-    """
-
-    pin: Optional[pa.typing.Series[int]]
-    mapreg_1: pa.typing.Series[str]
-    agency: pa.typing.Series[str]
-    opabrt: Optional[pa.typing.Series[str]]
-    location: pa.typing.Series[str]
-    status_1: pa.typing.Series[str]
-    councildistrict: pa.typing.Series[int]
-    sideyardeligible: pa.typing.Series[Literal["Yes", "No"]]
-    zoning: pa.typing.Series[str]
-    objectid: pa.typing.Series[int]
-    Shape__Area: pa.typing.Series[float]
-    Shape__Length: pa.typing.Series[float]
-
-    class Config:
-        strict = True  # Columns must match exactly
+CityOwnedPropertiesOutputSchema = pa.DataFrameSchema(
+    #TODO: confirm what's nullable and what isn't
+    columns = {
+        "opa_id": pa.Column(int, checks=pa.Check(lambda s: s.dropna() != "")),
+        "market_value": pa.Column(int),
+        "sale_date": pa.Column(pa.DateTime, nullable=True),
+        "sale_price": pa.Column(int, nullable=True),
+        "owner_1": pa.Column(str, nullable=True),
+        "owner_2": pa.Column(str, nullable=True),
+        "building_code_description": pa.Column(str, nullable=True),
+        "zip_code": pa.Column(str, nullable=True),
+        "zoning": pa.Column(str, nullable=True),
+        "parcel_type": pa.Column(str, nullable=True),
+        "standardized_address": pa.Column(str, nullable=True),
+        "vacant": pa.Column(pa.Bool, nullable=True),
+        "district": pa.Column(str, nullable=True),
+        "neighborhood": pa.Column(str, nullable=True),
+        "rco_info": pa.Column(str, nullable=True),
+        "rco_names": pa.Column(str, nullable=True),
+        "geometry": pa.Column("geometry"),
+        "city_owner_agency": pa.Column(str),
+        "side_yard_eligible": pa.Column(
+            pa.Category,
+            checks=pa.Check.isin(["Yes", "No"])
+        ),
+    },
+    strict=True
+)
 
 
 class CityOwnedPropertiesInputValidator(BaseValidator):
-    """Validator for access city owned properties service input."""
-
-    schema = None
+    """
+    Validator for the city-owned properties dataset input.
+    schema and _custom_validation() are used by validate() in the parent class.
+    """
+    schema = CityOwnedPropertiesInputSchema
 
     def _custom_validation(self, gdf: gpd.GeoDataFrame):
         pass
@@ -41,41 +68,10 @@ class CityOwnedPropertiesInputValidator(BaseValidator):
 class CityOwnedPropertiesOutputValidator(BaseValidator):
     """
     Validator for the city-owned properties dataset output.
-    _custom_validation() is called by validate() in the parent class.
+    schema and _custom_validation() are used by validate() in the parent class.
     """
 
-    schema = CityOwnedPropertiesSchema
+    schema = CityOwnedPropertiesOutputSchema
 
     def _custom_validation(self, gdf: gpd.GeoDataFrame):
-        # Row count check: expect approx. 7,796 plus/minus 20%
-        expected = 7796
-        lower = int(expected * 0.8)
-        upper = int(expected * 1.2)
-        if not lower <= len(gdf) <= upper:
-            self.errors.append(f"Expected ~7,796 records ±20%, but got {len(gdf)}")
-
-        # Check status_1 and agency are strings
-        if not gdf["status_1"].apply(lambda x: isinstance(x, str)).all():
-            self.errors.append("Some values in 'status_1' are not strings.")
-
-        if not gdf["agency"].apply(lambda x: isinstance(x, str)).all():
-            self.errors.append("Some values in 'agency' are not strings.")
-
-        # Check sideyardeligible values are "Yes" or "No"
-        allowed = {"Yes", "No"}
-        actual = set(gdf["sideyardeligible"].dropna().unique())
-        if not actual.issubset(allowed):
-            self.errors.append(
-                f"'sideyardeligible' column must contain only 'Yes' or 'No', but got: {actual}"
-            )
-
-        # Check that non-null opabrt values are non-empty strings
-        if (
-            not gdf["opabrt"]
-            .dropna()
-            .apply(lambda x: isinstance(x, str) and x.strip() != "")
-            .all()
-        ):
-            self.errors.append(
-                "Some non-null values in 'opabrt' are not valid non-empty strings."
-            )
+        pass

--- a/data/src/validation/city_owned_properties.py
+++ b/data/src/validation/city_owned_properties.py
@@ -1,5 +1,6 @@
 import geopandas as gpd
 import pandera.pandas as pa
+import pandas as pd
 from .base import BaseValidator
 
 # Expecting ~7,796 records returned (within ±20% tolerance).
@@ -10,8 +11,8 @@ upper = int(expected * 1.2)
 
 CityOwnedPropertiesInputSchema = pa.DataFrameSchema(
     columns={
-        "opa_id": pa.Column(int, checks=pa.Check(lambda s: s.dropna() != "")),
-        "agency": pa.Column(str, nullable=True),
+        "opa_id": pa.Column(pa.Int, checks=pa.Check(lambda s: s.dropna() != "")),
+        "agency": pa.Column(pa.String, nullable=True),
         "sideyardeligible": pa.Column(
             pa.Category, nullable=True, checks=pa.Check.isin(["Yes", "No"])
         ),
@@ -23,23 +24,23 @@ CityOwnedPropertiesInputSchema = pa.DataFrameSchema(
 
 CityOwnedPropertiesOutputSchema = pa.DataFrameSchema(
     columns={
-        "opa_id": pa.Column(int, checks=pa.Check(lambda s: s.dropna() != "")),
-        "market_value": pa.Column(int, nullable=True),
-        "sale_date": pa.Column(pa.DateTime, nullable=True),
-        "sale_price": pa.Column(int, nullable=True),
-        "owner_1": pa.Column(str, nullable=True),
-        "owner_2": pa.Column(str, nullable=True),
-        "building_code_description": pa.Column(str, nullable=True),
-        "zip_code": pa.Column(str, nullable=True),
-        "zoning": pa.Column(str, nullable=True),
-        "parcel_type": pa.Column(str, nullable=True),
-        "standardized_address": pa.Column(str, nullable=True),
+        "opa_id": pa.Column(pa.Int, checks=pa.Check(lambda s: s.dropna() != "")),
+        "market_value": pa.Column(pa.Int, nullable=True),
+        "sale_date": pa.Column(pd.DatetimeTZDtype(tz="UTC"), nullable=True),
+        "sale_price": pa.Column(pa.Float, nullable=True),
+        "owner_1": pa.Column(pa.String, nullable=True),
+        "owner_2": pa.Column(pa.String, nullable=True),
+        "building_code_description": pa.Column(pa.String, nullable=True),
+        "zip_code": pa.Column(pa.String, nullable=True),
+        "zoning": pa.Column(pa.String, nullable=True),
+        "parcel_type": pa.Column(pa.String, nullable=True),
+        "standardized_address": pa.Column(pa.String, nullable=True),
         "vacant": pa.Column(pa.Bool, nullable=True),
-        "district": pa.Column(str, nullable=True),
-        "neighborhood": pa.Column(str, nullable=True),
-        "rco_info": pa.Column(str, nullable=True),
-        "rco_names": pa.Column(str, nullable=True),
-        "city_owner_agency": pa.Column(str, nullable=True),
+        "district": pa.Column(pa.String, nullable=True),
+        "neighborhood": pa.Column(pa.String, nullable=True),
+        "rco_info": pa.Column(pa.String, nullable=True),
+        "rco_names": pa.Column(pa.String, nullable=True),
+        "city_owner_agency": pa.Column(pa.String, nullable=True),
         "side_yard_eligible": pa.Column(
             pa.Category, nullable=True, checks=pa.Check.isin(["Yes", "No"])
         ),

--- a/data/src/validation/city_owned_properties.py
+++ b/data/src/validation/city_owned_properties.py
@@ -9,24 +9,19 @@ lower = int(expected * 0.8)
 upper = int(expected * 1.2)
 
 CityOwnedPropertiesInputSchema = pa.DataFrameSchema(
-    columns = {
+    columns={
         "opa_id": pa.Column(int, checks=pa.Check(lambda s: s.dropna() != "")),
         "agency": pa.Column(str),
-        "sideyardeligible": pa.Column(
-            pa.Category,
-            checks=pa.Check.isin(["Yes", "No"])
-        ),
-        "geometry": pa.Column("geometry")
-    }, 
-    checks=pa.Check(
-        lambda df: lower <= df.shape[0] <= upper
-    ),
-    strict=True
+        "sideyardeligible": pa.Column(pa.Category, checks=pa.Check.isin(["Yes", "No"])),
+        "geometry": pa.Column("geometry"),
+    },
+    checks=pa.Check(lambda df: lower <= df.shape[0] <= upper),
+    strict=True,
 )
 
 CityOwnedPropertiesOutputSchema = pa.DataFrameSchema(
-    #TODO: confirm what's nullable and what isn't
-    columns = {
+    # TODO: confirm what's nullable and what isn't
+    columns={
         "opa_id": pa.Column(int, checks=pa.Check(lambda s: s.dropna() != "")),
         "market_value": pa.Column(int),
         "sale_date": pa.Column(pa.DateTime, nullable=True),
@@ -46,11 +41,10 @@ CityOwnedPropertiesOutputSchema = pa.DataFrameSchema(
         "geometry": pa.Column("geometry"),
         "city_owner_agency": pa.Column(str),
         "side_yard_eligible": pa.Column(
-            pa.Category,
-            checks=pa.Check.isin(["Yes", "No"])
+            pa.Category, checks=pa.Check.isin(["Yes", "No"])
         ),
     },
-    strict=True
+    strict=True,
 )
 
 
@@ -59,6 +53,7 @@ class CityOwnedPropertiesInputValidator(BaseValidator):
     Validator for the city-owned properties dataset input.
     schema and _custom_validation() are used by validate() in the parent class.
     """
+
     schema = CityOwnedPropertiesInputSchema
 
     def _custom_validation(self, gdf: gpd.GeoDataFrame):

--- a/data/src/validation/city_owned_properties.py
+++ b/data/src/validation/city_owned_properties.py
@@ -1,6 +1,31 @@
 import geopandas as gpd
-
+import pandera as pa
+from typing import Optional, Literal
 from .base import BaseValidator
+
+
+class CityOwnedPropertiesSchema(pa.DataFrameModel):
+    '''
+    Used for schema checks to ensure expected columns
+    are present with the correct types.
+
+    `Optional` typing means null values are allowed.
+    '''
+    pin: Optional[pa.typing.Series[int]]
+    mapreg_1: pa.typing.Series[str]
+    agency: pa.typing.Series[str]
+    opabrt: Optional[pa.typing.Series[str]]
+    location: pa.typing.Series[str]
+    status_1: pa.typing.Series[str]
+    councildistrict: pa.typing.Series[int]
+    sideyardeligible: pa.typing.Series[Literal["Yes", "No"]]
+    zoning: pa.typing.Series[str]
+    objectid: pa.typing.Series[int]
+    Shape__Area: pa.typing.Series[float]
+    Shape__Length: pa.typing.Series[float]
+
+    class Config:
+        strict = True   # Columns must match exactly
 
 
 class CityOwnedPropertiesInputValidator(BaseValidator):
@@ -13,9 +38,40 @@ class CityOwnedPropertiesInputValidator(BaseValidator):
 
 
 class CityOwnedPropertiesOutputValidator(BaseValidator):
-    """Validator for city owned properties service output."""
+    '''
+    Validator for the city-owned properties dataset output.
+    _custom_validation() is called by validate() in the parent class.
+    '''
 
-    schema = None
+    schema = CityOwnedPropertiesSchema
 
     def _custom_validation(self, gdf: gpd.GeoDataFrame):
-        pass
+        # Row count check: expect approx. 7,796 plus/minus 20%
+        expected = 7796
+        lower = int(expected * 0.8)
+        upper = int(expected * 1.2)
+        if not lower <= len(gdf) <= upper:
+            self.errors.append(
+                f"Expected ~7,796 records ±20%, but got {len(gdf)}"
+            )
+
+        # Check status_1 and agency are strings
+        if not gdf["status_1"].apply(lambda x: isinstance(x, str)).all():
+            self.errors.append("Some values in 'status_1' are not strings.")
+
+        if not gdf["agency"].apply(lambda x: isinstance(x, str)).all():
+            self.errors.append("Some values in 'agency' are not strings.")
+
+        # Check sideyardeligible values are "Yes" or "No"
+        allowed = {"Yes", "No"}
+        actual = set(gdf["sideyardeligible"].dropna().unique())
+        if not actual.issubset(allowed):
+            self.errors.append(
+                f"'sideyardeligible' column must contain only 'Yes' or 'No', but got: {actual}"
+            )
+
+        # Check that non-null opabrt values are non-empty strings
+        if not gdf["opabrt"].dropna().apply(lambda x: isinstance(x, str) and x.strip() != "").all():
+            self.errors.append(
+                "Some non-null values in 'opabrt' are not valid non-empty strings."
+            )

--- a/data/src/validation/city_owned_properties.py
+++ b/data/src/validation/city_owned_properties.py
@@ -11,8 +11,10 @@ upper = int(expected * 1.2)
 CityOwnedPropertiesInputSchema = pa.DataFrameSchema(
     columns={
         "opa_id": pa.Column(int, checks=pa.Check(lambda s: s.dropna() != "")),
-        "agency": pa.Column(str),
-        "sideyardeligible": pa.Column(pa.Category, checks=pa.Check.isin(["Yes", "No"])),
+        "agency": pa.Column(str, nullable=True),
+        "sideyardeligible": pa.Column(
+            pa.Category, nullable=True, checks=pa.Check.isin(["Yes", "No"])
+        ),
         "geometry": pa.Column("geometry"),
     },
     checks=pa.Check(lambda df: lower <= df.shape[0] <= upper),
@@ -20,10 +22,9 @@ CityOwnedPropertiesInputSchema = pa.DataFrameSchema(
 )
 
 CityOwnedPropertiesOutputSchema = pa.DataFrameSchema(
-    # TODO: confirm what's nullable and what isn't
     columns={
         "opa_id": pa.Column(int, checks=pa.Check(lambda s: s.dropna() != "")),
-        "market_value": pa.Column(int),
+        "market_value": pa.Column(int, nullable=True),
         "sale_date": pa.Column(pa.DateTime, nullable=True),
         "sale_price": pa.Column(int, nullable=True),
         "owner_1": pa.Column(str, nullable=True),
@@ -38,11 +39,11 @@ CityOwnedPropertiesOutputSchema = pa.DataFrameSchema(
         "neighborhood": pa.Column(str, nullable=True),
         "rco_info": pa.Column(str, nullable=True),
         "rco_names": pa.Column(str, nullable=True),
-        "geometry": pa.Column("geometry"),
-        "city_owner_agency": pa.Column(str),
+        "city_owner_agency": pa.Column(str, nullable=True),
         "side_yard_eligible": pa.Column(
-            pa.Category, checks=pa.Check.isin(["Yes", "No"])
+            pa.Category, nullable=True, checks=pa.Check.isin(["Yes", "No"])
         ),
+        "geometry": pa.Column("geometry"),
     },
     strict=True,
 )

--- a/data/src/validation/city_owned_properties.py
+++ b/data/src/validation/city_owned_properties.py
@@ -1,5 +1,5 @@
 import geopandas as gpd
-import pandera.pandera as pa
+import pandera.pandas as pa
 from typing import Optional, Literal
 from .base import BaseValidator
 

--- a/data/src/validation/city_owned_properties.py
+++ b/data/src/validation/city_owned_properties.py
@@ -5,12 +5,13 @@ from .base import BaseValidator
 
 
 class CityOwnedPropertiesSchema(pa.DataFrameModel):
-    '''
+    """
     Used for schema checks to ensure expected columns
     are present with the correct types.
 
     `Optional` typing means null values are allowed.
-    '''
+    """
+
     pin: Optional[pa.typing.Series[int]]
     mapreg_1: pa.typing.Series[str]
     agency: pa.typing.Series[str]
@@ -25,7 +26,7 @@ class CityOwnedPropertiesSchema(pa.DataFrameModel):
     Shape__Length: pa.typing.Series[float]
 
     class Config:
-        strict = True   # Columns must match exactly
+        strict = True  # Columns must match exactly
 
 
 class CityOwnedPropertiesInputValidator(BaseValidator):
@@ -38,10 +39,10 @@ class CityOwnedPropertiesInputValidator(BaseValidator):
 
 
 class CityOwnedPropertiesOutputValidator(BaseValidator):
-    '''
+    """
     Validator for the city-owned properties dataset output.
     _custom_validation() is called by validate() in the parent class.
-    '''
+    """
 
     schema = CityOwnedPropertiesSchema
 
@@ -51,9 +52,7 @@ class CityOwnedPropertiesOutputValidator(BaseValidator):
         lower = int(expected * 0.8)
         upper = int(expected * 1.2)
         if not lower <= len(gdf) <= upper:
-            self.errors.append(
-                f"Expected ~7,796 records ±20%, but got {len(gdf)}"
-            )
+            self.errors.append(f"Expected ~7,796 records ±20%, but got {len(gdf)}")
 
         # Check status_1 and agency are strings
         if not gdf["status_1"].apply(lambda x: isinstance(x, str)).all():
@@ -71,7 +70,12 @@ class CityOwnedPropertiesOutputValidator(BaseValidator):
             )
 
         # Check that non-null opabrt values are non-empty strings
-        if not gdf["opabrt"].dropna().apply(lambda x: isinstance(x, str) and x.strip() != "").all():
+        if (
+            not gdf["opabrt"]
+            .dropna()
+            .apply(lambda x: isinstance(x, str) and x.strip() != "")
+            .all()
+        ):
             self.errors.append(
                 "Some non-null values in 'opabrt' are not valid non-empty strings."
             )

--- a/data/src/validation/council_dists.py
+++ b/data/src/validation/council_dists.py
@@ -1,5 +1,5 @@
 import geopandas as gpd
-import pandera as pa
+import pandera.pandera as pa
 from .base import BaseValidator
 
 

--- a/data/src/validation/council_dists.py
+++ b/data/src/validation/council_dists.py
@@ -9,27 +9,28 @@ CouncilDistrictsInputSchema = pa.DataFrameSchema(
         lambda df: set(df["district"].dropna().unique())
         == {str(i) for i in range(1, 11)}
     ),
+    nullable=True,
     strict=True,
 )
 
 CouncilDistrictsOutputSchema = pa.DataFrameSchema(
     columns={
         "opa_id": pa.Column(pa.String),
-        "market_value": pa.Column(pa.Int),
-        "sale_date": pa.Column(pa.DateTime),
-        "sale_price": pa.Column(pa.Int),
+        "market_value": pa.Column(pa.Int, nullable=True),
+        "sale_date": pa.Column(pa.DateTime, nullable=True),
+        "sale_price": pa.Column(pa.Int, nullable=True),
         "owner_1": pa.Column(pa.String, nullable=True),
         "owner_2": pa.Column(pa.String, nullable=True),
         "building_code_description": pa.Column(pa.String, nullable=True),
         "zip_code": pa.Column(pa.String, nullable=True),
         "zoning": pa.Column(pa.String, nullable=True),
-        "geometry": pa.Column("geometry"),
         "parcel_type": pa.Column(pa.String, nullable=True),
         "standardized_address": pa.Column(pa.String, nullable=True),
-        "vacant": pa.Column(pa.Bool),
+        "vacant": pa.Column(pa.Bool, nullable=True),
         "district": pa.Column(
-            str, checks=pa.Check.isin([str(i) for i in range(1, 11)])
+            str, nullable=True, checks=pa.Check.isin([str(i) for i in range(1, 11)])
         ),
+        "geometry": pa.Column("geometry"),
     },
     strict=True,
 )

--- a/data/src/validation/council_dists.py
+++ b/data/src/validation/council_dists.py
@@ -1,5 +1,5 @@
 import geopandas as gpd
-import pandera.pandera as pa
+import pandera.pandas as pa
 from .base import BaseValidator
 
 

--- a/data/src/validation/council_dists.py
+++ b/data/src/validation/council_dists.py
@@ -3,13 +3,18 @@ import pandera.pandas as pa
 from .base import BaseValidator
 
 CouncilDistrictsInputSchema = pa.DataFrameSchema(
-    columns={"district": pa.Column(str), "geometry": pa.Column("geometry")},
+    columns={
+        "district": pa.Column(
+            str,
+            nullable=True,
+        ),
+        "geometry": pa.Column("geometry"),
+    },
     # district should contain 10 records of strings 1-10
     checks=pa.Check(
         lambda df: set(df["district"].dropna().unique())
         == {str(i) for i in range(1, 11)}
     ),
-    nullable=True,
     strict=True,
 )
 

--- a/data/src/validation/council_dists.py
+++ b/data/src/validation/council_dists.py
@@ -1,6 +1,17 @@
 import geopandas as gpd
-
+import pandera as pa
 from .base import BaseValidator
+
+class CouncilDistrictsSchema(pa.DataFrameModel):
+    OBJECTID_1: pa.typing.Series[int]
+    OBJECTID: pa.typing.Series[int]
+    DISTRICT: pa.typing.Series[str]
+    SHAPE_LENG: pa.typing.Series[float]
+    Shape__Area: pa.typing.Series[float]
+    Shape__Length: pa.typing.Series[float]
+
+    class Config:
+        strict = True  # Columns must match exactly
 
 
 class CouncilDistrictsInputValidator(BaseValidator):
@@ -14,8 +25,19 @@ class CouncilDistrictsInputValidator(BaseValidator):
 
 class CouncilDistrictsOutputValidator(BaseValidator):
     """Validator for council districts service output."""
-
-    schema = None
+    schema = CouncilDistrictsSchema
 
     def _custom_validation(self, gdf: gpd.GeoDataFrame):
-        pass
+        # Check there are exactly 10 rows
+        if len(gdf) != 10:
+            self.errors.append(
+                f"Expected 10 council district records, got {len(gdf)}"
+            )
+
+        # Check "district" values are exactly "1" through "10"
+        expected = {str(i) for i in range(1, 11)}
+        actual = list(gdf["district"])
+        if actual != expected:
+            self.errors.append(
+                f"'district' column values must be strings '1' through '10', but got: {sorted(actual)}"
+            )

--- a/data/src/validation/council_dists.py
+++ b/data/src/validation/council_dists.py
@@ -2,6 +2,7 @@ import geopandas as gpd
 import pandera as pa
 from .base import BaseValidator
 
+
 class CouncilDistrictsSchema(pa.DataFrameModel):
     OBJECTID_1: pa.typing.Series[int]
     OBJECTID: pa.typing.Series[int]
@@ -25,14 +26,13 @@ class CouncilDistrictsInputValidator(BaseValidator):
 
 class CouncilDistrictsOutputValidator(BaseValidator):
     """Validator for council districts service output."""
+
     schema = CouncilDistrictsSchema
 
     def _custom_validation(self, gdf: gpd.GeoDataFrame):
         # Check there are exactly 10 rows
         if len(gdf) != 10:
-            self.errors.append(
-                f"Expected 10 council district records, got {len(gdf)}"
-            )
+            self.errors.append(f"Expected 10 council district records, got {len(gdf)}")
 
         # Check "district" values are exactly "1" through "10"
         expected = {str(i) for i in range(1, 11)}

--- a/data/src/validation/council_dists.py
+++ b/data/src/validation/council_dists.py
@@ -1,5 +1,6 @@
 import geopandas as gpd
 import pandera.pandas as pa
+import pandas as pd
 from .base import BaseValidator
 
 CouncilDistrictsInputSchema = pa.DataFrameSchema(
@@ -21,16 +22,16 @@ CouncilDistrictsInputSchema = pa.DataFrameSchema(
 CouncilDistrictsOutputSchema = pa.DataFrameSchema(
     columns={
         "opa_id": pa.Column(pa.String),
+        "street_address": pa.Column(pa.String, nullable=True),
         "market_value": pa.Column(pa.Int, nullable=True),
-        "sale_date": pa.Column(pa.DateTime, nullable=True),
-        "sale_price": pa.Column(pa.Int, nullable=True),
+        "sale_date": pa.Column(pd.DatetimeTZDtype(tz="UTC"), nullable=True),
+        "sale_price": pa.Column(pa.Float, nullable=True),
         "owner_1": pa.Column(pa.String, nullable=True),
         "owner_2": pa.Column(pa.String, nullable=True),
         "building_code_description": pa.Column(pa.String, nullable=True),
         "zip_code": pa.Column(pa.String, nullable=True),
         "zoning": pa.Column(pa.String, nullable=True),
         "parcel_type": pa.Column(pa.String, nullable=True),
-        "standardized_address": pa.Column(pa.String, nullable=True),
         "vacant": pa.Column(pa.Bool, nullable=True),
         "district": pa.Column(
             str, nullable=True, checks=pa.Check.isin([str(i) for i in range(1, 11)])

--- a/data/src/validation/council_dists.py
+++ b/data/src/validation/council_dists.py
@@ -3,19 +3,18 @@ import pandera.pandas as pa
 from .base import BaseValidator
 
 CouncilDistrictsInputSchema = pa.DataFrameSchema(
-    columns = {
-        "district": pa.Column(str),
-        "geometry": pa.Column("geometry")
-    },
+    columns={"district": pa.Column(str), "geometry": pa.Column("geometry")},
     # district should contain 10 records of strings 1-10
-    checks=pa.Check(lambda df: set(df["district"].dropna().unique()) \
-                                    == {str(i) for i in range(1, 11)}),
-    strict=True
+    checks=pa.Check(
+        lambda df: set(df["district"].dropna().unique())
+        == {str(i) for i in range(1, 11)}
+    ),
+    strict=True,
 )
 
 CouncilDistrictsOutputSchema = pa.DataFrameSchema(
     columns={
-        "opa_id": pa.Column(pa.String),  # Assuming it may include leading zeros
+        "opa_id": pa.Column(pa.String),
         "market_value": pa.Column(pa.Int),
         "sale_date": pa.Column(pa.DateTime),
         "sale_price": pa.Column(pa.Int),
@@ -29,9 +28,10 @@ CouncilDistrictsOutputSchema = pa.DataFrameSchema(
         "standardized_address": pa.Column(pa.String, nullable=True),
         "vacant": pa.Column(pa.Bool),
         "district": pa.Column(
-            str,checks=pa.Check.isin([str(i) for i in range(1, 11)])),
+            str, checks=pa.Check.isin([str(i) for i in range(1, 11)])
+        ),
     },
-    strict=True
+    strict=True,
 )
 
 
@@ -50,4 +50,4 @@ class CouncilDistrictsOutputValidator(BaseValidator):
     schema = CouncilDistrictsOutputSchema
 
     def _custom_validation(self, gdf: gpd.GeoDataFrame):
-        pass        
+        pass


### PR DESCRIPTION
# External Input Validator -- Council Districts and City-Owned Properties

## Checklist:

Before submitting your PR, please confirm that you have done the following:

- [x] I have opened my PR against the `staging` branch, NOT against `main`
- [x] I've run the relevant formatting and linting tools listed in the setup docs
- [x] I have commented hard-to-understand areas in my code
- [x] I've reviewed any merge conflicts to make sure they are resolved
- [x] My changes generate no new warnings

## Description

As part of the larger data pipeline validation implementation, this PR creates custom schemas/validators for external data sources, namely council districts and city owned properties. When running these two stages of the data pipeline, their base validation functions will call their custom validations and schema checks, which make up the content of these two files. 
Note that geometry validator is already being called by the base validator so we don't need to include that in the new code. 

## Related Issue(s)

This PR addresses issues #1237 and #1238 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## How Has This Been Tested?
I reran the pipeline with changes to ensure no new errors or warnings were being displayed for the affected pipeline stages. I also created a local script with fake data to ensure the validations were flagging errors as expected. A dedicated directory for unit tests would be ideal, but unsure if we want to commit to do that for every validator. 