### PR TITLE
Fix filter view not switching to property details when map property is selected

### DIFF
--- a/src/app/find-properties/[[...opa_id]]/page.tsx
+++ b/src/app/find-properties/[[...opa_id]]/page.tsx
@@ -128,6 +128,12 @@ const MapPage = ({ params }: MapPageProps) => {
     history.replaceState(null, '', `/find-properties/${opa_id}`);
   }, [selectedProperty]);
 
+  useEffect(() => {
+    if (selectedProperty && currentView === 'filter') {
+      setCurrentView('detail');
+    }
+  }, [selectedProperty, currentView]);
+
   const updateCurrentView = (view: BarClickOptions) => {
     setCurrentView(view === currentView ? 'detail' : view);
     if (


### PR DESCRIPTION
This PR fixes a user experience issue where selecting a property on the map wouldn't show the property details if someone was currently viewing the filter panel.
The fix automatically switches from the filter view to the property details view whenever someone clicks on a property on the map. Now when users are filtering properties and then click on one they're interested in, they immediately see the property information without having to navigate away from the filters first.